### PR TITLE
🔒️ fix(agent): fail closed when tool visibility cannot be resolved

### DIFF
--- a/cmd/stellad/builtin_tools.go
+++ b/cmd/stellad/builtin_tools.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"context"
+
+	"github.com/CherryHQ/stella/internal/agent"
+	sessionaccess "github.com/CherryHQ/stella/internal/agent/session/access"
+	"github.com/CherryHQ/stella/internal/connections"
+	"github.com/CherryHQ/stella/internal/email"
+	"github.com/CherryHQ/stella/internal/goal"
+	"github.com/CherryHQ/stella/internal/library"
+	"github.com/CherryHQ/stella/internal/memory"
+	"github.com/CherryHQ/stella/internal/notify"
+	"github.com/CherryHQ/stella/internal/recally"
+	"github.com/CherryHQ/stella/internal/scheduler"
+	sharepkg "github.com/CherryHQ/stella/internal/share"
+	"github.com/CherryHQ/stella/internal/vault"
+	workflowpkg "github.com/CherryHQ/stella/internal/workflow"
+	pkgplugins "github.com/CherryHQ/stella/pkg/plugins"
+	pkgtools "github.com/CherryHQ/stella/pkg/tools"
+)
+
+// builtinToolDeps names every service the default builtin tool set is built
+// from. Assembling the set in one function keeps the list of tools a deployment
+// puts in front of the model enumerable by a test, rather than spread across
+// three appends in the middle of service construction.
+type builtinToolDeps struct {
+	Notifier    pkgplugins.Notifier
+	Memory      memory.Provider
+	Recall      memory.RecallSource
+	GroupRecall memory.GroupRecallSource
+	Goal        *goal.Service
+	Session     *sessionaccess.Service
+	Library     *library.Service
+	Scheduler   *scheduler.Service
+	Workflow    *workflowpkg.Service
+	Credentials *connections.Service
+	Email       *email.Service
+	Share       *sharepkg.Service
+	Recally     *recally.Service
+	Vault       *vault.Service
+}
+
+// newBuiltinTools returns the builtin tools in the order they are offered to the
+// runner. A nil Vault omits the vault tool, the one dependency whose absence
+// removes a tool rather than merely gating it.
+func newBuiltinTools(d builtinToolDeps) []agent.BuiltinTool {
+	builtins := []agent.BuiltinTool{{
+		Tool: memory.BuildTool(d.Memory, memory.WithRecallSource(d.Recall), memory.WithGroupRecallSource(d.GroupRecall)),
+	}}
+	if notifyTool := notify.NewTool(d.Notifier); notifyTool != nil {
+		builtins = append(builtins, agent.BuiltinTool{Tool: notifyTool})
+	}
+	builtins = append(builtins,
+		agent.BuiltinTool{Tool: goal.NewTool(d.Goal), Available: agent.BuiltinToolAvailable},
+		agent.BuiltinTool{Tool: sessionaccess.NewTool(d.Session), Available: func(ctx context.Context, params agent.RunnerParams) (bool, error) {
+			baseline, err := agent.BuiltinToolAvailable(ctx, params)
+			if err != nil {
+				return false, err
+			}
+			return params.GroupID == "" && baseline, nil
+		}},
+		agent.BuiltinTool{Tool: library.NewTool(d.Library), Available: libraryToolAvailable},
+		agent.BuiltinTool{Tool: scheduler.NewTool(d.Scheduler), Available: agent.BuiltinToolAvailable},
+		agent.BuiltinTool{Tool: workflowpkg.NewTool(d.Workflow), Available: agent.BuiltinToolAvailable},
+		agent.BuiltinTool{Tool: connections.NewTool(d.Credentials), Available: oauthToolAvailable(d.Credentials)},
+		agent.BuiltinTool{Tool: email.NewTool(d.Email), Available: emailToolAvailable(d.Vault)},
+		agent.BuiltinTool{Tool: sharepkg.NewTool(d.Share), Available: agent.BuiltinToolAvailable},
+	)
+	// Recally is one tool per action: the provider validates each call against an
+	// exact schema instead of a union that accepts every action's fields.
+	for _, spec := range recally.ActionTools() {
+		builtins = append(builtins, agent.BuiltinTool{
+			Build: func(build pkgplugins.ToolBuildContext) (pkgtools.Tool, error) {
+				return recally.NewRuntimeTool(d.Recally, build.Runtime, spec), nil
+			},
+			Spec:      recally.NewTool(d.Recally, spec).Definition(),
+			Available: agent.BuiltinToolAvailable,
+		})
+	}
+	if d.Vault != nil {
+		builtins = append(builtins, agent.BuiltinTool{Tool: vault.NewTool(d.Vault, d.Credentials), Available: agent.BuiltinToolAvailable})
+	}
+	return builtins
+}

--- a/cmd/stellad/builtin_tools_test.go
+++ b/cmd/stellad/builtin_tools_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	agentsandbox "github.com/CherryHQ/stella/internal/agent/sandbox"
+	skillstool "github.com/CherryHQ/stella/internal/skills"
 	"github.com/CherryHQ/stella/internal/vault"
 	pkgchannel "github.com/CherryHQ/stella/pkg/channel"
 )
@@ -30,7 +31,7 @@ func (stubNotifier) NotifyUser(context.Context, string, pkgchannel.Notification)
 var defaultModelFacingTools = []string{
 	"bash",
 	"view_image",
-	"skills",
+	skillstool.ToolName,
 	"memory",
 	"notify",
 	"goal",
@@ -62,7 +63,7 @@ var defaultModelFacingTools = []string{
 // because a nil one removes its tool from the set entirely.
 func defaultToolNames(t *testing.T) []string {
 	t.Helper()
-	names := []string{"skills"}
+	names := []string{skillstool.ToolName}
 	for _, core := range agentsandbox.ToolDefinitionsWithAvailability() {
 		names = append(names, core.Definition.Name)
 	}

--- a/cmd/stellad/builtin_tools_test.go
+++ b/cmd/stellad/builtin_tools_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	agentsandbox "github.com/CherryHQ/stella/internal/agent/sandbox"
+	"github.com/CherryHQ/stella/internal/vault"
+	pkgchannel "github.com/CherryHQ/stella/pkg/channel"
+)
+
+type stubNotifier struct{}
+
+func (stubNotifier) Notify(context.Context, pkgchannel.Notification) error { return nil }
+
+func (stubNotifier) NotifyUser(context.Context, string, pkgchannel.Notification) error { return nil }
+
+// defaultModelFacingTools is a golden record of the tool names a default
+// deployment puts in front of the model: the sandbox core tools, the skills
+// tool, and every builtin. It exists for the action-split work (#1173), where
+// one tool name becomes several: this list is the one place a rename, addition,
+// or removal has to show up as a reviewable diff instead of being discovered in
+// production. Update it deliberately, together with the skills, prompts, and
+// tool_override rows that carry the same names — never just to make the test
+// pass.
+//
+// Deliberately not covered, because they vary per deployment rather than being
+// part of the default surface: plugin tools, MCP tools, and per-run tools.
+var defaultModelFacingTools = []string{
+	"bash",
+	"view_image",
+	"skills",
+	"memory",
+	"notify",
+	"goal",
+	"session",
+	"library_search",
+	"scheduler",
+	"workflow",
+	"oauth",
+	"email",
+	"share",
+	"recally_digest",
+	"recally_digest_save",
+	"recally_entry_add",
+	"recally_entry_list",
+	"recally_entry_update",
+	"recally_feed_add",
+	"recally_feed_list",
+	"recally_feed_poll",
+	"recally_feed_remove",
+	"recally_get_article",
+	"recally_list_articles",
+	"recally_save_article",
+	"vault",
+}
+
+// defaultToolNames is the same surface the runner assembles, minus the pieces
+// that need a live deployment. Services stay nil: a tool's Definition never
+// reaches its service. The notifier and the vault are the two exceptions,
+// because a nil one removes its tool from the set entirely.
+func defaultToolNames(t *testing.T) []string {
+	t.Helper()
+	names := []string{"skills"}
+	for _, core := range agentsandbox.ToolDefinitionsWithAvailability() {
+		names = append(names, core.Definition.Name)
+	}
+	for _, builtin := range newBuiltinTools(builtinToolDeps{Notifier: stubNotifier{}, Vault: &vault.Service{}}) {
+		definition, ok := builtin.Definition()
+		if !ok || definition.Name == "" {
+			t.Fatalf("builtin tool has no usable definition: %#v", definition)
+		}
+		names = append(names, definition.Name)
+	}
+	slices.Sort(names)
+	return names
+}
+
+func TestDefaultToolNamesMatchGolden(t *testing.T) {
+	got := defaultToolNames(t)
+	want := slices.Clone(defaultModelFacingTools)
+	slices.Sort(want)
+	if !slices.Equal(got, want) {
+		t.Fatalf("the model-facing tool names changed.\n got: %q\nwant: %q\nIf this is intended, update defaultModelFacingTools along with the skills, prompts, and docs naming these tools.", got, want)
+	}
+}

--- a/cmd/stellad/commands.go
+++ b/cmd/stellad/commands.go
@@ -508,8 +508,12 @@ func setup(parent context.Context, cfg config.ServerConfig, baseURL string) (*se
 
 	serviceTools := []agent.BuiltinTool{
 		{Tool: goal.NewTool(goalSvc), Available: agent.BuiltinToolAvailable},
-		{Tool: sessionaccess.NewTool(sessionAccess), Available: func(ctx context.Context, params agent.RunnerParams) bool {
-			return params.GroupID == "" && agent.BuiltinToolAvailable(ctx, params)
+		{Tool: sessionaccess.NewTool(sessionAccess), Available: func(ctx context.Context, params agent.RunnerParams) (bool, error) {
+			baseline, err := agent.BuiltinToolAvailable(ctx, params)
+			if err != nil {
+				return false, err
+			}
+			return params.GroupID == "" && baseline, nil
 		}},
 		{
 			Tool:      library.NewTool(librarySvc),

--- a/cmd/stellad/commands.go
+++ b/cmd/stellad/commands.go
@@ -300,11 +300,6 @@ func setup(parent context.Context, cfg config.ServerConfig, baseURL string) (*se
 	}
 	sessionInbox := sessioninbox.New(db)
 
-	var builtinTools []agent.BuiltinTool
-	if notifyTool := notify.NewTool(dispatcher); notifyTool != nil {
-		builtinTools = append(builtinTools, agent.BuiltinTool{Tool: notifyTool})
-	}
-
 	pluginToolsBuilder := func(ctx context.Context, build pkgplugins.ToolBuildContext) []pkgtools.Tool {
 		return phost.BuildEnabledTools(ctx, build)
 	}
@@ -386,10 +381,6 @@ func setup(parent context.Context, cfg config.ServerConfig, baseURL string) (*se
 	if !ok {
 		return nil, fmt.Errorf("memory provider does not implement group recall")
 	}
-	builtinTools = append([]agent.BuiltinTool{{
-		Tool: memory.BuildTool(memProvider, memory.WithRecallSource(sessionAccess), memory.WithGroupRecallSource(groupRecall)),
-	}}, builtinTools...)
-
 	if err := registerReflectBuiltin(schedulerSvc, reflect.Config{
 		Memory:            memProvider,
 		Store:             store,
@@ -506,40 +497,22 @@ func setup(parent context.Context, cfg config.ServerConfig, baseURL string) (*se
 	}
 	mcpSvc := mcp.NewServiceForPool(db, mcpVault)
 
-	serviceTools := []agent.BuiltinTool{
-		{Tool: goal.NewTool(goalSvc), Available: agent.BuiltinToolAvailable},
-		{Tool: sessionaccess.NewTool(sessionAccess), Available: func(ctx context.Context, params agent.RunnerParams) (bool, error) {
-			baseline, err := agent.BuiltinToolAvailable(ctx, params)
-			if err != nil {
-				return false, err
-			}
-			return params.GroupID == "" && baseline, nil
-		}},
-		{
-			Tool:      library.NewTool(librarySvc),
-			Available: libraryToolAvailable,
-		},
-		{Tool: scheduler.NewTool(schedulerSvc), Available: agent.BuiltinToolAvailable},
-		{Tool: workflowpkg.NewTool(workflowSvc), Available: agent.BuiltinToolAvailable},
-		{Tool: connections.NewTool(credSvc), Available: oauthToolAvailable(credSvc)},
-		{Tool: email.NewTool(emailSvc), Available: emailToolAvailable(vaultSvc)},
-		{Tool: sharepkg.NewTool(shareSvc), Available: agent.BuiltinToolAvailable},
-	}
-	// Recally is one tool per action: the provider validates each call against an
-	// exact schema instead of a union that accepts every action's fields.
-	for _, spec := range recally.ActionTools() {
-		serviceTools = append(serviceTools, agent.BuiltinTool{
-			Build: func(build pkgplugins.ToolBuildContext) (pkgtools.Tool, error) {
-				return recally.NewRuntimeTool(recallySvc, build.Runtime, spec), nil
-			},
-			Spec:      recally.NewTool(recallySvc, spec).Definition(),
-			Available: agent.BuiltinToolAvailable,
-		})
-	}
-	if vaultSvc != nil {
-		serviceTools = append(serviceTools, agent.BuiltinTool{Tool: vault.NewTool(vaultSvc, credSvc), Available: agent.BuiltinToolAvailable})
-	}
-	builtinTools = append(builtinTools, serviceTools...)
+	builtinTools := newBuiltinTools(builtinToolDeps{
+		Notifier:    dispatcher,
+		Memory:      memProvider,
+		Recall:      sessionAccess,
+		GroupRecall: groupRecall,
+		Goal:        goalSvc,
+		Session:     sessionAccess,
+		Library:     librarySvc,
+		Scheduler:   schedulerSvc,
+		Workflow:    workflowSvc,
+		Credentials: credSvc,
+		Email:       emailSvc,
+		Share:       shareSvc,
+		Recally:     recallySvc,
+		Vault:       vaultSvc,
+	})
 
 	poolMgr = agent.NewPoolManager(store, memProvider,
 		agent.WithSnapshotLoader(snapshotLoader),

--- a/cmd/stellad/plugin_runtime_test.go
+++ b/cmd/stellad/plugin_runtime_test.go
@@ -119,9 +119,13 @@ func TestDirectToolRegistryExecuteBashAndWebFetch(t *testing.T) {
 	host := &passthroughHost{workDir: workDir}
 	reg := pkgtools.NewRegistry()
 	for _, tool := range agentsandbox.NewTools(host, nil, nil) {
-		reg.Register(tool)
+		if err := reg.Register(tool); err != nil {
+			t.Fatalf("register %s: %v", tool.Definition().Name, err)
+		}
 	}
-	reg.Register(webfetch.New())
+	if err := reg.Register(webfetch.New()); err != nil {
+		t.Fatalf("register webfetch: %v", err)
+	}
 	defer func() { _ = reg.Close() }()
 
 	bashResult, err := reg.Execute(context.Background(), "bash", map[string]any{"command": "pwd -P"})

--- a/cmd/stellad/tool_availability.go
+++ b/cmd/stellad/tool_availability.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/jackc/pgx/v5"
 
@@ -21,41 +22,54 @@ type oauthProviderStatusGetter interface {
 // libraryToolAvailable accepts every authorized user-representing Agent run,
 // independent of channel or session kind. Group runs stay excluded because
 // they deliberately carry no trusted user identity.
-func libraryToolAvailable(ctx context.Context, params agent.RunnerParams) bool {
-	return params.GroupID == "" && agent.BuiltinToolAvailable(ctx, params)
+func libraryToolAvailable(ctx context.Context, params agent.RunnerParams) (bool, error) {
+	baseline, err := agent.BuiltinToolAvailable(ctx, params)
+	if err != nil {
+		return false, err
+	}
+	return params.GroupID == "" && baseline, nil
 }
 
-func emailToolAvailable(v emailConfigMetaGetter) func(context.Context, agent.RunnerParams) bool {
-	return func(ctx context.Context, params agent.RunnerParams) bool {
-		if !agent.BuiltinToolAvailable(ctx, params) {
-			return false
+// emailToolAvailable gates the email tool on a stored EMAIL_CONFIG. A vault
+// lookup that fails is reported, not guessed: the caller fails the runner build
+// and retries, rather than caching a tool that can send mail on the user's
+// behalf (or caching its absence) from one bad query.
+func emailToolAvailable(v emailConfigMetaGetter) func(context.Context, agent.RunnerParams) (bool, error) {
+	return func(ctx context.Context, params agent.RunnerParams) (bool, error) {
+		baseline, err := agent.BuiltinToolAvailable(ctx, params)
+		if err != nil || !baseline {
+			return false, err
 		}
 		if v == nil {
-			return true
+			return true, nil
 		}
-		_, err := v.GetScopedMeta(ctx, vault.ScopeUser, params.UserID, "", "EMAIL_CONFIG")
-		if err == nil {
-			return true
+		_, err = v.GetScopedMeta(ctx, vault.ScopeUser, params.UserID, "", "EMAIL_CONFIG")
+		switch {
+		case err == nil:
+			return true, nil
+		case errors.Is(err, pgx.ErrNoRows):
+			return false, nil
+		default:
+			return false, fmt.Errorf("read email config: %w", err)
 		}
-		if errors.Is(err, pgx.ErrNoRows) {
-			return false
-		}
-		return true
 	}
 }
 
-func oauthToolAvailable(s oauthProviderStatusGetter) func(context.Context, agent.RunnerParams) bool {
-	return func(ctx context.Context, params agent.RunnerParams) bool {
-		if !agent.BuiltinToolAvailable(ctx, params) {
-			return false
+// oauthToolAvailable gates the oauth tool on at least one configured provider,
+// and reports a failed status query for the same reason emailToolAvailable does.
+func oauthToolAvailable(s oauthProviderStatusGetter) func(context.Context, agent.RunnerParams) (bool, error) {
+	return func(ctx context.Context, params agent.RunnerParams) (bool, error) {
+		baseline, err := agent.BuiltinToolAvailable(ctx, params)
+		if err != nil || !baseline {
+			return false, err
 		}
 		if s == nil {
-			return true
+			return true, nil
 		}
 		configured, err := s.AnyProviderConfigured(ctx, params.UserID)
 		if err != nil {
-			return true
+			return false, fmt.Errorf("read oauth provider status: %w", err)
 		}
-		return configured
+		return configured, nil
 	}
 }

--- a/cmd/stellad/tool_availability_test.go
+++ b/cmd/stellad/tool_availability_test.go
@@ -24,7 +24,11 @@ func TestLibraryToolAvailable(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			if got := libraryToolAvailable(context.Background(), test.params); got != test.want {
+			got, err := libraryToolAvailable(context.Background(), test.params)
+			if err != nil {
+				t.Fatalf("libraryToolAvailable: %v", err)
+			}
+			if got != test.want {
 				t.Fatalf("libraryToolAvailable = %v, want %v", got, test.want)
 			}
 		})
@@ -46,31 +50,65 @@ func (f fakeOAuthStatuses) AnyProviderConfigured(context.Context, string) (bool,
 	return f.configured, f.err
 }
 
-func TestEmailToolAvailableRequiresEmailConfigAndFailsOpen(t *testing.T) {
+func TestEmailToolAvailableRequiresEmailConfig(t *testing.T) {
 	params := agent.RunnerParams{UserID: "u1", AgentID: "a1"}
-	if !emailToolAvailable(fakeEmailMetaGetter{})(context.Background(), params) {
-		t.Fatal("EMAIL_CONFIG present should mount email tool")
+	available, err := emailToolAvailable(fakeEmailMetaGetter{})(context.Background(), params)
+	if err != nil || !available {
+		t.Fatalf("EMAIL_CONFIG present should mount email tool: available=%v err=%v", available, err)
 	}
-	if emailToolAvailable(fakeEmailMetaGetter{err: pgx.ErrNoRows})(context.Background(), params) {
-		t.Fatal("missing EMAIL_CONFIG should skip email tool")
+	available, err = emailToolAvailable(fakeEmailMetaGetter{err: pgx.ErrNoRows})(context.Background(), params)
+	if err != nil || available {
+		t.Fatalf("missing EMAIL_CONFIG should skip email tool: available=%v err=%v", available, err)
 	}
-	if !emailToolAvailable(fakeEmailMetaGetter{err: errors.New("db down")})(context.Background(), params) {
-		t.Fatal("predicate errors should fail open")
+	available, err = emailToolAvailable(fakeEmailMetaGetter{})(context.Background(), agent.RunnerParams{AgentID: "a1"})
+	if err != nil || available {
+		t.Fatalf("builtin tool base predicate should still reject missing user: available=%v err=%v", available, err)
 	}
-	if emailToolAvailable(fakeEmailMetaGetter{})(context.Background(), agent.RunnerParams{AgentID: "a1"}) {
-		t.Fatal("builtin tool base predicate should still reject missing user")
+}
+
+// A vault outage must not be answered with a guess in either direction: the
+// runner build fails and the caller retries.
+func TestEmailToolAvailableReportsLookupFailure(t *testing.T) {
+	params := agent.RunnerParams{UserID: "u1", AgentID: "a1"}
+	lookupErr := errors.New("db down")
+	available, err := emailToolAvailable(fakeEmailMetaGetter{err: lookupErr})(context.Background(), params)
+	if err == nil {
+		t.Fatal("vault lookup failure should be reported, not defaulted")
+	}
+	if !errors.Is(err, lookupErr) {
+		t.Fatalf("error should wrap the lookup failure, got %v", err)
+	}
+	if available {
+		t.Fatal("availability must be false when unknown")
 	}
 }
 
 func TestOauthToolAvailableRequiresConfiguredProvider(t *testing.T) {
 	params := agent.RunnerParams{UserID: "u1", AgentID: "a1"}
-	if oauthToolAvailable(fakeOAuthStatuses{})(context.Background(), params) {
-		t.Fatal("no configured providers should skip oauth tool")
+	available, err := oauthToolAvailable(fakeOAuthStatuses{})(context.Background(), params)
+	if err != nil || available {
+		t.Fatalf("no configured providers should skip oauth tool: available=%v err=%v", available, err)
 	}
-	if !oauthToolAvailable(fakeOAuthStatuses{configured: true})(context.Background(), params) {
-		t.Fatal("configured provider should mount oauth tool")
+	available, err = oauthToolAvailable(fakeOAuthStatuses{configured: true})(context.Background(), params)
+	if err != nil || !available {
+		t.Fatalf("configured provider should mount oauth tool: available=%v err=%v", available, err)
 	}
-	if oauthToolAvailable(fakeOAuthStatuses{configured: true})(context.Background(), agent.RunnerParams{UserID: "u1"}) {
-		t.Fatal("builtin tool base predicate should still reject missing agent")
+	available, err = oauthToolAvailable(fakeOAuthStatuses{configured: true})(context.Background(), agent.RunnerParams{UserID: "u1"})
+	if err != nil || available {
+		t.Fatalf("builtin tool base predicate should still reject missing agent: available=%v err=%v", available, err)
+	}
+}
+
+func TestOauthToolAvailableReportsStatusFailure(t *testing.T) {
+	statusErr := errors.New("db down")
+	available, err := oauthToolAvailable(fakeOAuthStatuses{configured: true, err: statusErr})(context.Background(), agent.RunnerParams{UserID: "u1", AgentID: "a1"})
+	if err == nil {
+		t.Fatal("provider status failure should be reported, not defaulted")
+	}
+	if !errors.Is(err, statusErr) {
+		t.Fatalf("error should wrap the status failure, got %v", err)
+	}
+	if available {
+		t.Fatal("availability must be false when unknown")
 	}
 }

--- a/internal/agent/builtin_tool_test.go
+++ b/internal/agent/builtin_tool_test.go
@@ -25,7 +25,11 @@ func TestBuiltinToolAvailable(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := BuiltinToolAvailable(context.Background(), tt.p); got != tt.want {
+			got, err := BuiltinToolAvailable(context.Background(), tt.p)
+			if err != nil {
+				t.Fatalf("BuiltinToolAvailable: %v", err)
+			}
+			if got != tt.want {
 				t.Fatalf("BuiltinToolAvailable=%v want %v", got, tt.want)
 			}
 		})

--- a/internal/agent/delegate/chat_boundary_test.go
+++ b/internal/agent/delegate/chat_boundary_test.go
@@ -31,7 +31,7 @@ func TestManagedSessionCreateAppliesPresetWithoutDelegateSurface(t *testing.T) {
 	presets := NewPresetRegistry([]DelegatePreset{{Name: "coder", System: "coder instructions", Timeout: time.Minute}})
 	tool := NewDelegateTool(DelegateConfig{
 		SessionRunner: runner,
-		Registry:      registryWith("session", "read_file"),
+		Registry:      registryWith(t, "session", "read_file"),
 		Presets:       presets,
 	})
 	ctx := memory.WithSessionID(context.Background(), "source")
@@ -51,10 +51,13 @@ func (t stubTool) Execute(context.Context, map[string]any) (string, error) {
 	return "", nil
 }
 
-func registryWith(names ...string) *tools.Registry {
+func registryWith(t *testing.T, names ...string) *tools.Registry {
+	t.Helper()
 	r := tools.NewRegistry()
 	for _, name := range names {
-		r.Register(stubTool{name: name})
+		if err := r.Register(stubTool{name: name}); err != nil {
+			t.Fatalf("register %s: %v", name, err)
+		}
 	}
 	return r
 }
@@ -67,7 +70,7 @@ func registryWith(names ...string) *tools.Registry {
 // conversation that spawned the run.
 func TestDelegateRunDropsParentChatBinding(t *testing.T) {
 	runner := &capturingRunner{}
-	tool := NewDelegateTool(DelegateConfig{SessionRunner: runner, Registry: registryWith("read_file")})
+	tool := NewDelegateTool(DelegateConfig{SessionRunner: runner, Registry: registryWith(t, "read_file")})
 
 	parent := agentctx.WithChatBinding(context.Background(), agentctx.ChatBinding{
 		Channel:    "group:g1",
@@ -89,7 +92,7 @@ func TestDelegateRunDropsParentChatBinding(t *testing.T) {
 }
 
 func TestDelegateVisibilityUsesWhitelistNotPermanentExclusion(t *testing.T) {
-	reg := registryWith("read_file", delegateToolName)
+	reg := registryWith(t, "read_file", delegateToolName)
 	tool := NewDelegateTool(DelegateConfig{SessionRunner: &capturingRunner{}, Registry: reg})
 
 	for _, tc := range []struct {
@@ -113,7 +116,7 @@ func TestDelegateVisibilityUsesWhitelistNotPermanentExclusion(t *testing.T) {
 
 func TestDelegateChildCanNestWithinDepthAndRejectsCycle(t *testing.T) {
 	first := &capturingRunner{}
-	tool := NewDelegateTool(DelegateConfig{SessionRunner: first, Registry: registryWith("session", delegateToolName)})
+	tool := NewDelegateTool(DelegateConfig{SessionRunner: first, Registry: registryWith(t, "session", delegateToolName)})
 	parent := memory.WithSessionID(context.Background(), "session-a")
 	if result := tool.runDelegate(parent, delegateTaskConfig{ID: "b", Task: "work", SessionID: "session-b"}); result.Error != "" {
 		t.Fatalf("A -> B: %s", result.Error)

--- a/internal/agent/runner_builder.go
+++ b/internal/agent/runner_builder.go
@@ -37,10 +37,14 @@ type MCPToolProvider interface {
 }
 
 type BuiltinTool struct {
-	Tool      tools.Tool
-	Build     func(pkgplugins.ToolBuildContext) (tools.Tool, error)
-	Spec      tools.Definition
-	Available func(context.Context, RunnerParams) bool
+	Tool  tools.Tool
+	Build func(pkgplugins.ToolBuildContext) (tools.Tool, error)
+	Spec  tools.Definition
+	// Available reports whether this tool belongs in the runner's registry for
+	// the given run. An error means the answer is unknown; callers must fail the
+	// build instead of guessing, so a transient dependency outage can never be
+	// cached as either a missing capability or a wrongly granted one.
+	Available func(context.Context, RunnerParams) (bool, error)
 }
 
 func (b BuiltinTool) Definition() (tools.Definition, bool) {
@@ -122,8 +126,8 @@ func newRunnerScratch(stellaHome string) (string, func() error, error) {
 	return dir, cleanup, nil
 }
 
-func BuiltinToolAvailable(_ context.Context, params RunnerParams) bool {
-	return params.UserID != "" && params.AgentID != ""
+func BuiltinToolAvailable(_ context.Context, params RunnerParams) (bool, error) {
+	return params.UserID != "" && params.AgentID != "", nil
 }
 
 // runnerBuilderConfig holds all dependencies needed to assemble a NewRunnerFunc.

--- a/internal/agent/runner_impl.go
+++ b/internal/agent/runner_impl.go
@@ -218,6 +218,23 @@ func buildStreamFunc(cfg runnerConfig) (providers.StreamFunc, error) {
 	return stream, nil
 }
 
+// Tool sources, used to name both sides of a tool-name collision in the error
+// the runner build fails with.
+const (
+	toolSourceCore    = "core"
+	toolSourceBuiltin = "builtin"
+	toolSourcePerRun  = "per-run"
+	toolSourceMCP     = "mcp"
+	toolSourcePlugin  = "plugin"
+)
+
+// toolCandidate is a non-core tool awaiting the override filter, carrying where
+// it came from so a duplicate name can be attributed.
+type toolCandidate struct {
+	tool   tools.Tool
+	source string
+}
+
 // buildToolRegistry creates the tool registry with core, builtin, and external tools.
 func buildToolRegistry(ctx context.Context, cfg runnerConfig, session pkgsandbox.Session, stream providers.StreamFunc, model ai.Model, systemPrompt string) (*tools.Registry, *hooks.HookSet, *delegatetool.DelegateTool, error) {
 	toolReg := tools.NewRegistry()
@@ -239,12 +256,16 @@ func buildToolRegistry(ctx context.Context, cfg runnerConfig, session pkgsandbox
 
 	// Sandbox core tools route through the active session and must win over any
 	// process-local tool of the same name, which would bypass sandbox policy.
+	sourceByName := make(map[string]string, len(coreTools))
 	for _, t := range coreTools {
-		toolReg.Register(t)
+		if err := toolReg.Register(t); err != nil {
+			return nil, nil, nil, fmt.Errorf("runner: register core tool: %w", err)
+		}
+		sourceByName[t.Definition().Name] = toolSourceCore
 	}
 
-	var nonCoreCandidates []tools.Tool
-	registerNonCore := func(t tools.Tool) {
+	var nonCoreCandidates []toolCandidate
+	registerNonCore := func(source string, t tools.Tool) {
 		name := t.Definition().Name
 		// Check the complete reservation set, not only core tools registered in
 		// this runner. Legacy core names remain reserved even when no runtime tool
@@ -254,12 +275,29 @@ func buildToolRegistry(ctx context.Context, cfg runnerConfig, session pkgsandbox
 				"component", "go_runner", "tool", name, "reason", "reserved core tool name")
 			return
 		}
-		nonCoreCandidates = append(nonCoreCandidates, t)
+		nonCoreCandidates = append(nonCoreCandidates, toolCandidate{tool: t, source: source})
+	}
+
+	// Names of every builtin the deployment ships, available or not. Overrides
+	// naming one of these are current rows for a tool this run cannot use, not
+	// stale rows, so they must not be reported as orphans below.
+	knownBuiltinNames := make(map[string]struct{}, len(cfg.BuiltinTools))
+	for _, entry := range cfg.BuiltinTools {
+		if definition, ok := entry.Definition(); ok {
+			knownBuiltinNames[definition.Name] = struct{}{}
+		}
 	}
 
 	for _, entry := range cfg.BuiltinTools {
-		if entry.Available != nil && !entry.Available(ctx, cfg.BuiltinParams) {
-			continue
+		if entry.Available != nil {
+			available, err := entry.Available(ctx, cfg.BuiltinParams)
+			if err != nil {
+				definition, _ := entry.Definition()
+				return nil, nil, nil, fmt.Errorf("runner: resolve availability for builtin tool %q: %w", definition.Name, err)
+			}
+			if !available {
+				continue
+			}
 		}
 		if (entry.Tool == nil) == (entry.Build == nil) {
 			return nil, nil, nil, fmt.Errorf("runner: builtin tool requires exactly one of Tool or Build")
@@ -281,27 +319,27 @@ func buildToolRegistry(ctx context.Context, cfg runnerConfig, session pkgsandbox
 				return nil, nil, nil, fmt.Errorf("runner: built builtin tool name %q does not match static definition %q", definition.Name, entry.Spec.Name)
 			}
 		}
-		registerNonCore(tool)
+		registerNonCore(toolSourceBuiltin, tool)
 	}
 	for _, t := range cfg.PerRunTools {
-		registerNonCore(t)
+		registerNonCore(toolSourcePerRun, t)
 	}
 	skillsTool, err := skillstool.NewTool(cfg.SkillRevisionReader, session, cfg.SkillReadAuthorizer)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("runner: build skills tool: %w", err)
 	}
-	registerNonCore(skillsTool.
+	registerNonCore(toolSourceBuiltin, skillsTool.
 		WithProjectSnapshot(cfg.ProjectSkillSnapshot).
 		WithPluginVisibility(cfg.PluginView.RegisteredPluginIDs, cfg.PluginView.EnabledPluginIDs).
 		WithAgentSkillPolicy(cfg.DisabledSkillRefs))
 	if cfg.MCPToolProvider != nil {
 		for _, t := range cfg.MCPToolProvider.ToolsForContext(ctx, cfg.BuiltinParams.UserID, cfg.BuiltinParams.AgentID) {
-			registerNonCore(t)
+			registerNonCore(toolSourceMCP, t)
 		}
 	}
 	if cfg.PluginTools != nil {
 		for _, t := range cfg.PluginTools(ctx, bc) {
-			registerNonCore(t)
+			registerNonCore(toolSourcePlugin, t)
 		}
 	}
 
@@ -324,20 +362,57 @@ func buildToolRegistry(ctx context.Context, cfg runnerConfig, session pkgsandbox
 	if cfg.ToolOverrideFetcher != nil {
 		rows, err := cfg.ToolOverrideFetcher(ctx, cfg.BuiltinParams.UserID, cfg.BuiltinParams.AgentID)
 		if err != nil {
-			slog.Warn("failed to load tool overrides; using default tool visibility", "error", err)
-		} else {
-			overrides = rows
+			// Defaulting to "visible" here would hand the model every tool an
+			// administrator had switched off, for as long as this runner lives.
+			return nil, nil, nil, fmt.Errorf("runner: load tool overrides: %w", err)
 		}
+		overrides = rows
 	}
-	for _, t := range nonCoreCandidates {
-		name := t.Definition().Name
+	// Every name this runner could have served, whether or not an override kept
+	// it out, so a legitimately disabled tool is not mistaken for a stale row.
+	knownNames := make(map[string]struct{}, len(sourceByName)+len(nonCoreCandidates)+len(knownBuiltinNames))
+	for name := range sourceByName {
+		knownNames[name] = struct{}{}
+	}
+	for name := range knownBuiltinNames {
+		knownNames[name] = struct{}{}
+	}
+	for _, c := range nonCoreCandidates {
+		knownNames[c.tool.Definition().Name] = struct{}{}
+	}
+
+	for _, c := range nonCoreCandidates {
+		name := c.tool.Definition().Name
 		if !FilterToolEnabled(true, name, overrides) {
 			continue
 		}
-		toolReg.Register(t)
+		if err := toolReg.Register(c.tool); err != nil {
+			return nil, nil, nil, fmt.Errorf("runner: register %s tool %q (name already taken by the %s tool): %w",
+				c.source, name, sourceByName[name], err)
+		}
+		sourceByName[name] = c.source
 	}
+	warnOrphanOverrides(overrides, knownNames)
 
 	return toolReg, hookSet, delegateTool, nil
+}
+
+// warnOrphanOverrides reports override rows that name no tool this deployment
+// knows about. A stale row is a data problem, not a runner fault: a renamed or
+// removed tool leaves its row behind, and failing the build over it would lock
+// the user out of a working agent. Log it instead, so the row gets cleaned up
+// before a future tool reuses the name and silently inherits the old setting.
+func warnOrphanOverrides(overrides []ToolOverride, known map[string]struct{}) {
+	for _, row := range overrides {
+		if _, ok := known[row.ToolName]; ok {
+			continue
+		}
+		if IsCoreToolName(row.ToolName) {
+			continue
+		}
+		slog.Warn("tool override names a tool this runner does not know; ignoring",
+			"component", "go_runner", "tool", row.ToolName, "scope", row.Scope, "enabled", row.Enabled)
+	}
 }
 
 func filterRunnerTools(reg *tools.Registry, excluded []string) (coreagent.ToolSet, []tools.Definition, error) {
@@ -347,6 +422,14 @@ func filterRunnerTools(reg *tools.Registry, excluded []string) (coreagent.ToolSe
 	blocked := make(map[string]struct{}, len(excluded))
 	for _, name := range excluded {
 		if name == "" {
+			continue
+		}
+		if !reg.Has(name) {
+			// A caller excluding a tool this runner never had is working from a
+			// stale name list, not asking for something impossible. Hiding nothing
+			// is the right outcome; say so instead of failing the run.
+			slog.Warn("excluded tool is not registered for this runner; ignoring",
+				"component", "go_runner", "tool", name)
 			continue
 		}
 		blocked[name] = struct{}{}

--- a/internal/agent/runner_impl.go
+++ b/internal/agent/runner_impl.go
@@ -292,6 +292,12 @@ func buildToolRegistry(ctx context.Context, cfg runnerConfig, session pkgsandbox
 		if entry.Available != nil {
 			available, err := entry.Available(ctx, cfg.BuiltinParams)
 			if err != nil {
+				// A cancelled run is a cancelled run, not a dependency that failed
+				// to answer. Reporting it as a visibility fault would send callers
+				// retrying a build nobody is waiting for.
+				if ctxErr := ctx.Err(); ctxErr != nil {
+					return nil, nil, nil, fmt.Errorf("runner: build tool registry: %w", ctxErr)
+				}
 				definition, _ := entry.Definition()
 				return nil, nil, nil, fmt.Errorf("runner: resolve availability for builtin tool %q: %w", definition.Name, err)
 			}
@@ -346,12 +352,19 @@ func buildToolRegistry(ctx context.Context, cfg runnerConfig, session pkgsandbox
 	// Settle name ownership before any override is consulted. A plugin that
 	// claims a builtin's name has to fail the build now: deferring the check to
 	// the enabled set would let the grab sit dormant and detonate on the day an
-	// operator re-enables the builtin it shadowed.
+	// operator re-enables the builtin it shadowed. A builtin's name is reserved
+	// deployment-wide, not per run, for the same reason: otherwise a plugin
+	// could take "email" on every run without EMAIL_CONFIG and only collide once
+	// the vault entry exists.
 	for _, c := range nonCoreCandidates {
 		name := c.tool.Definition().Name
 		if prior, taken := sourceByName[name]; taken {
 			return nil, nil, nil, fmt.Errorf("runner: %s tool %q collides with the %s tool of the same name",
 				c.source, name, prior)
+		}
+		if _, reserved := knownBuiltinNames[name]; reserved && c.source != toolSourceBuiltin {
+			return nil, nil, nil, fmt.Errorf("runner: %s tool %q collides with the %s tool of the same name (not available for this run)",
+				c.source, name, toolSourceBuiltin)
 		}
 		sourceByName[name] = c.source
 	}
@@ -375,6 +388,9 @@ func buildToolRegistry(ctx context.Context, cfg runnerConfig, session pkgsandbox
 	if cfg.ToolOverrideFetcher != nil {
 		rows, err := cfg.ToolOverrideFetcher(ctx, cfg.BuiltinParams.UserID, cfg.BuiltinParams.AgentID)
 		if err != nil {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return nil, nil, nil, fmt.Errorf("runner: build tool registry: %w", ctxErr)
+			}
 			// Defaulting to "visible" here would hand the model every tool an
 			// administrator had switched off, for as long as this runner lives.
 			return nil, nil, nil, fmt.Errorf("runner: load tool overrides: %w", err)

--- a/internal/agent/runner_impl.go
+++ b/internal/agent/runner_impl.go
@@ -343,6 +343,19 @@ func buildToolRegistry(ctx context.Context, cfg runnerConfig, session pkgsandbox
 		}
 	}
 
+	// Settle name ownership before any override is consulted. A plugin that
+	// claims a builtin's name has to fail the build now: deferring the check to
+	// the enabled set would let the grab sit dormant and detonate on the day an
+	// operator re-enables the builtin it shadowed.
+	for _, c := range nonCoreCandidates {
+		name := c.tool.Definition().Name
+		if prior, taken := sourceByName[name]; taken {
+			return nil, nil, nil, fmt.Errorf("runner: %s tool %q collides with the %s tool of the same name",
+				c.source, name, prior)
+		}
+		sourceByName[name] = c.source
+	}
+
 	hookSet := buildHookSet(cfg)
 	delegateTool := delegatetool.NewDelegateTool(delegatetool.DelegateConfig{
 		Stream:         stream,
@@ -368,31 +381,18 @@ func buildToolRegistry(ctx context.Context, cfg runnerConfig, session pkgsandbox
 		}
 		overrides = rows
 	}
-	// Every name this runner could have served, whether or not an override kept
-	// it out, so a legitimately disabled tool is not mistaken for a stale row.
-	knownNames := make(map[string]struct{}, len(sourceByName)+len(nonCoreCandidates)+len(knownBuiltinNames))
-	for name := range sourceByName {
-		knownNames[name] = struct{}{}
-	}
-	for name := range knownBuiltinNames {
-		knownNames[name] = struct{}{}
-	}
-	for _, c := range nonCoreCandidates {
-		knownNames[c.tool.Definition().Name] = struct{}{}
-	}
-
 	for _, c := range nonCoreCandidates {
 		name := c.tool.Definition().Name
 		if !FilterToolEnabled(true, name, overrides) {
 			continue
 		}
+		// Names were settled above, so this only fires if that pass and the
+		// registry ever disagree.
 		if err := toolReg.Register(c.tool); err != nil {
-			return nil, nil, nil, fmt.Errorf("runner: register %s tool %q (name already taken by the %s tool): %w",
-				c.source, name, sourceByName[name], err)
+			return nil, nil, nil, fmt.Errorf("runner: register %s tool: %w", c.source, err)
 		}
-		sourceByName[name] = c.source
 	}
-	warnOrphanOverrides(overrides, knownNames)
+	warnOrphanOverrides(overrides, sourceByName, knownBuiltinNames)
 
 	return toolReg, hookSet, delegateTool, nil
 }
@@ -402,9 +402,15 @@ func buildToolRegistry(ctx context.Context, cfg runnerConfig, session pkgsandbox
 // removed tool leaves its row behind, and failing the build over it would lock
 // the user out of a working agent. Log it instead, so the row gets cleaned up
 // before a future tool reuses the name and silently inherits the old setting.
-func warnOrphanOverrides(overrides []ToolOverride, known map[string]struct{}) {
+// known holds every name this runner could have served (core plus every
+// candidate, whether or not an override kept it out); knownBuiltins covers
+// builtins this deployment ships but this run cannot use.
+func warnOrphanOverrides(overrides []ToolOverride, known map[string]string, knownBuiltins map[string]struct{}) {
 	for _, row := range overrides {
 		if _, ok := known[row.ToolName]; ok {
+			continue
+		}
+		if _, ok := knownBuiltins[row.ToolName]; ok {
 			continue
 		}
 		if IsCoreToolName(row.ToolName) {

--- a/internal/agent/runner_impl_test.go
+++ b/internal/agent/runner_impl_test.go
@@ -80,7 +80,9 @@ func withTestRunnerPaths(t *testing.T, cfg runnerConfig) runnerConfig {
 func TestRunnerChatOmitsExcludedToolsFromProviderRequest(t *testing.T) {
 	reg := tools.NewRegistry()
 	for _, name := range []string{"bash", "read", "write", "edit"} {
-		reg.Register(&stubTool{name: name})
+		if err := reg.Register(&stubTool{name: name}); err != nil {
+			t.Fatalf("register %s: %v", name, err)
+		}
 	}
 
 	var got []string
@@ -122,9 +124,11 @@ func TestRunnerChatOmitsExcludedToolsFromProviderRequest(t *testing.T) {
 
 func TestFilterRunnerTools(t *testing.T) {
 	reg := tools.NewRegistry()
-	reg.Register(&stubTool{name: "zeta"})
-	reg.Register(&stubTool{name: "middle"})
-	reg.Register(&stubTool{name: "alpha"})
+	for _, name := range []string{"zeta", "middle", "alpha"} {
+		if err := reg.Register(&stubTool{name: name}); err != nil {
+			t.Fatalf("register %s: %v", name, err)
+		}
+	}
 
 	set, defs, err := filterRunnerTools(reg, []string{"middle", "not-registered"})
 	if err != nil {

--- a/internal/agent/runtime/runner_cache_test.go
+++ b/internal/agent/runtime/runner_cache_test.go
@@ -1151,3 +1151,51 @@ func TestRunnerCache_InvalidGroupSessionFailsClosedWithoutRunner(t *testing.T) {
 		t.Fatal("no session entry should be installed for an invalid session")
 	}
 }
+
+// A failed build must leave nothing behind. The fail-closed tool-visibility
+// work (#1173) leans on this: it turns a transient dependency outage into a
+// build error on purpose, which is only recoverable because the cache neither
+// keeps the half-made session entry nor remembers the failure. The next turn
+// has to reach the factory again and see live state.
+func TestRunnerCacheDoesNotCacheAFailedBuild(t *testing.T) {
+	buildErr := errors.New("load tool overrides: database unreachable")
+	outage := true
+	recovered := newFakeRunner()
+	var calls int
+	cache := newRunnerCache(func(context.Context, RunnerParams) (Runner, error) {
+		calls++
+		if outage {
+			return nil, buildErr
+		}
+		return recovered, nil
+	}, fakeMemory{}, 10*time.Minute, slog.Default())
+	info := validInfo("failed-build")
+
+	if _, _, err := cache.getOrCreate(context.Background(), info, "", ""); !errors.Is(err, buildErr) {
+		t.Fatalf("first getOrCreate err = %v, want the build error", err)
+	}
+	cache.mu.Lock()
+	leftover, cached := cache.sessions[info.ID]
+	cache.mu.Unlock()
+	if cached {
+		t.Fatalf("failed build left a session entry behind: %#v", leftover)
+	}
+
+	// Still failing: the cache must ask the factory again rather than replay the
+	// remembered error.
+	if _, _, err := cache.getOrCreate(context.Background(), info, "", ""); !errors.Is(err, buildErr) {
+		t.Fatalf("second getOrCreate err = %v, want the build error", err)
+	}
+	if calls != 2 {
+		t.Fatalf("factory calls = %d, want 2; a negative cache would have short-circuited", calls)
+	}
+
+	outage = false
+	_, r, err := cache.getOrCreate(context.Background(), info, "", "")
+	if err != nil {
+		t.Fatalf("retry after recovery: %v", err)
+	}
+	if r != Runner(recovered) {
+		t.Fatalf("retry returned %#v, want the runner built after recovery", r)
+	}
+}

--- a/internal/agent/tool_visibility_failclosed_test.go
+++ b/internal/agent/tool_visibility_failclosed_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/CherryHQ/stella/internal/agent/sandbox"
 	"github.com/CherryHQ/stella/pkg/ai"
+	pkgplugins "github.com/CherryHQ/stella/pkg/plugins"
 	pkgtools "github.com/CherryHQ/stella/pkg/tools"
 )
 
@@ -97,6 +98,70 @@ func TestBuildToolRegistryRejectsDuplicateNonCoreName(t *testing.T) {
 		if !strings.Contains(err.Error(), want) {
 			t.Fatalf("error should mention %q, got %v", want, err)
 		}
+	}
+}
+
+// The collision is settled before overrides are read, so a name grab cannot lie
+// dormant behind a disabled incumbent and detonate the day it is switched back on.
+func TestBuildToolRegistryRejectsDuplicateNameWhileIncumbentIsDisabled(t *testing.T) {
+	cfg := failClosedConfig(t)
+	cfg.BuiltinTools = []BuiltinTool{{Tool: staticTool{name: "share"}}}
+	cfg.PluginTools = func(context.Context, pkgplugins.ToolBuildContext) []pkgtools.Tool {
+		return []pkgtools.Tool{staticTool{name: "share"}}
+	}
+	cfg.ToolOverrideFetcher = func(context.Context, string, string) ([]ToolOverride, error) {
+		return []ToolOverride{{ToolName: "share", Scope: ToolOverrideScopeUserAgent, Enabled: false}}, nil
+	}
+
+	_, _, _, err := buildToolRegistry(context.Background(), cfg, &fakeSession{alive: true}, nil, ai.Model{}, "")
+	if err == nil {
+		t.Fatal("expected the runner build to fail even though the incumbent is disabled")
+	}
+	if !strings.Contains(err.Error(), toolSourcePlugin) {
+		t.Fatalf("error should name the plugin claiming the name, got %v", err)
+	}
+}
+
+// The load-bearing assumption behind failing closed: nothing degraded is kept,
+// so the retry that follows a transient outage sees the real answer. Both a
+// failed availability probe and a failed override fetch are exercised, because
+// caching either one would outlive the outage.
+func TestBuildToolRegistryRetryAfterOutageSeesLiveState(t *testing.T) {
+	cfg := failClosedConfig(t)
+	outage := true
+	cfg.BuiltinTools = []BuiltinTool{
+		{Tool: staticTool{name: "memory"}},
+		{
+			Tool: staticTool{name: "email"},
+			Available: func(context.Context, RunnerParams) (bool, error) {
+				if outage {
+					return false, errors.New("vault unreachable")
+				}
+				return true, nil
+			},
+		},
+	}
+	cfg.ToolOverrideFetcher = func(context.Context, string, string) ([]ToolOverride, error) {
+		if outage {
+			return nil, errors.New("database unreachable")
+		}
+		return []ToolOverride{{ToolName: "memory", Scope: ToolOverrideScopeUserAgent, Enabled: false}}, nil
+	}
+
+	if _, _, _, err := buildToolRegistry(context.Background(), cfg, &fakeSession{alive: true}, nil, ai.Model{}, ""); err == nil {
+		t.Fatal("expected the first build to fail during the outage")
+	}
+
+	outage = false
+	reg, _, _, err := buildToolRegistry(context.Background(), cfg, &fakeSession{alive: true}, nil, ai.Model{}, "")
+	if err != nil {
+		t.Fatalf("retry after recovery: %v", err)
+	}
+	if !reg.Has("email") {
+		t.Fatal("email should be available once the probe answers again")
+	}
+	if reg.Has("memory") {
+		t.Fatal("the recovered fetch disables memory; a cached default-visible set would have kept it")
 	}
 }
 

--- a/internal/agent/tool_visibility_failclosed_test.go
+++ b/internal/agent/tool_visibility_failclosed_test.go
@@ -122,6 +122,86 @@ func TestBuildToolRegistryRejectsDuplicateNameWhileIncumbentIsDisabled(t *testin
 	}
 }
 
+// A builtin's name is reserved for the deployment, not for the runs where it
+// happens to be available. Without this, a plugin could hold "email" on every
+// run that lacks EMAIL_CONFIG and collide only once the vault entry appears.
+func TestBuildToolRegistryReservesUnavailableBuiltinNames(t *testing.T) {
+	cfg := failClosedConfig(t)
+	cfg.BuiltinTools = []BuiltinTool{{
+		Tool:      staticTool{name: "email"},
+		Available: func(context.Context, RunnerParams) (bool, error) { return false, nil },
+	}}
+	cfg.PluginTools = func(context.Context, pkgplugins.ToolBuildContext) []pkgtools.Tool {
+		return []pkgtools.Tool{staticTool{name: "email"}}
+	}
+
+	_, _, _, err := buildToolRegistry(context.Background(), cfg, &fakeSession{alive: true}, nil, ai.Model{}, "")
+	if err == nil {
+		t.Fatal("expected the runner build to fail on a plugin claiming an unavailable builtin's name")
+	}
+	for _, want := range []string{"email", toolSourcePlugin, toolSourceBuiltin} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error should mention %q, got %v", want, err)
+		}
+	}
+}
+
+// A cancelled run must be reported as cancellation. Dressing it up as a
+// dependency failure would send the caller retrying a build nobody awaits.
+func TestBuildToolRegistryReportsCancellationNotVisibilityFailure(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		prepare func(*runnerConfig)
+	}{
+		{
+			name: "availability probe",
+			prepare: func(cfg *runnerConfig) {
+				cfg.BuiltinTools = []BuiltinTool{{
+					Tool: staticTool{name: "email"},
+					Available: func(ctx context.Context, _ RunnerParams) (bool, error) {
+						// What a pool returns after it is closed under a cancelled
+						// run: an error of its own that does not wrap context.
+						return false, errors.New("closed pool")
+					},
+				}}
+			},
+		},
+		{
+			name: "override fetch",
+			prepare: func(cfg *runnerConfig) {
+				cfg.BuiltinTools = []BuiltinTool{{Tool: staticTool{name: "memory"}}}
+				cfg.ToolOverrideFetcher = func(context.Context, string, string) ([]ToolOverride, error) {
+					return nil, errors.New("closed pool")
+				}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			logs := captureLogs(t)
+			cfg := failClosedConfig(t)
+			tc.prepare(&cfg)
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+
+			_, _, _, err := buildToolRegistry(ctx, cfg, &fakeSession{alive: true}, nil, ai.Model{}, "")
+			if err == nil {
+				t.Fatal("expected the runner build to fail")
+			}
+			if !errors.Is(err, context.Canceled) {
+				t.Fatalf("error should report cancellation, got %v", err)
+			}
+			for _, unwanted := range []string{"resolve availability", "load tool overrides"} {
+				if strings.Contains(err.Error(), unwanted) {
+					t.Fatalf("cancellation must not be reported as %q: %v", unwanted, err)
+				}
+			}
+			if logs.Len() != 0 {
+				t.Fatalf("cancellation should not log a visibility fault: %s", logs.String())
+			}
+		})
+	}
+}
+
 // The load-bearing assumption behind failing closed: nothing degraded is kept,
 // so the retry that follows a transient outage sees the real answer. Both a
 // failed availability probe and a failed override fetch are exercised, because

--- a/internal/agent/tool_visibility_failclosed_test.go
+++ b/internal/agent/tool_visibility_failclosed_test.go
@@ -1,0 +1,162 @@
+package agent
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/CherryHQ/stella/internal/agent/sandbox"
+	"github.com/CherryHQ/stella/pkg/ai"
+	pkgtools "github.com/CherryHQ/stella/pkg/tools"
+)
+
+func failClosedConfig(t *testing.T) runnerConfig {
+	t.Helper()
+	home := t.TempDir()
+	return runnerConfig{
+		Sandbox: sandbox.Config{Paths: sandbox.Paths{
+			StellaHome: home,
+			AgentRoot:  filepath.Join(home, "agents", "agent-1"),
+			UserRoot:   filepath.Join(home, "users", "user-1"),
+		}},
+		BuiltinParams:       RunnerParams{UserID: "user-1", AgentID: "agent-1"},
+		SkillRevisionReader: emptySkillRuntime{},
+		SkillReadAuthorizer: allowSkillReads{},
+	}
+}
+
+// captureLogs redirects slog for the duration of the test and returns the buffer.
+func captureLogs(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var logs bytes.Buffer
+	previous := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(previous) })
+	return &logs
+}
+
+// An availability check that cannot answer must not be read as "unavailable":
+// that would quietly strip a capability for the whole life of the runner.
+func TestBuildToolRegistryFailsWhenAvailabilityIsUnknown(t *testing.T) {
+	cfg := failClosedConfig(t)
+	probeErr := errors.New("vault unreachable")
+	cfg.BuiltinTools = []BuiltinTool{{
+		Tool: staticTool{name: "email"},
+		Available: func(context.Context, RunnerParams) (bool, error) {
+			return false, probeErr
+		},
+	}}
+
+	_, _, _, err := buildToolRegistry(context.Background(), cfg, &fakeSession{alive: true}, nil, ai.Model{}, "")
+	if err == nil {
+		t.Fatal("expected the runner build to fail while availability is unknown")
+	}
+	if !errors.Is(err, probeErr) {
+		t.Fatalf("error should wrap the availability failure, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "email") {
+		t.Fatalf("error should name the tool, got %v", err)
+	}
+}
+
+// The inverse of the fail-open bug this replaces: a failed override fetch used
+// to leave every tool visible, including ones an administrator had disabled.
+func TestBuildToolRegistryFailsWhenOverrideFetchFails(t *testing.T) {
+	cfg := failClosedConfig(t)
+	fetchErr := errors.New("database unreachable")
+	cfg.BuiltinTools = []BuiltinTool{{Tool: staticTool{name: "memory"}}}
+	cfg.ToolOverrideFetcher = func(context.Context, string, string) ([]ToolOverride, error) {
+		return nil, fetchErr
+	}
+
+	_, _, _, err := buildToolRegistry(context.Background(), cfg, &fakeSession{alive: true}, nil, ai.Model{}, "")
+	if err == nil {
+		t.Fatal("expected the runner build to fail when overrides cannot be loaded")
+	}
+	if !errors.Is(err, fetchErr) {
+		t.Fatalf("error should wrap the fetch failure, got %v", err)
+	}
+}
+
+// Two tools under one name means model calls reach an implementation nobody
+// chose. Fail the build and name both sides so the collision is fixable.
+func TestBuildToolRegistryRejectsDuplicateNonCoreName(t *testing.T) {
+	cfg := failClosedConfig(t)
+	cfg.BuiltinTools = []BuiltinTool{{Tool: staticTool{name: "share"}}}
+	cfg.PerRunTools = []pkgtools.Tool{staticTool{name: "share"}}
+
+	_, _, _, err := buildToolRegistry(context.Background(), cfg, &fakeSession{alive: true}, nil, ai.Model{}, "")
+	if err == nil {
+		t.Fatal("expected the runner build to fail on a duplicate tool name")
+	}
+	for _, want := range []string{"share", toolSourceBuiltin, toolSourcePerRun} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error should mention %q, got %v", want, err)
+		}
+	}
+}
+
+// A row left behind by a renamed or removed tool is stale data. Warn, and keep
+// building: failing here would lock the user out of a working agent.
+func TestBuildToolRegistryWarnsOnOrphanOverride(t *testing.T) {
+	logs := captureLogs(t)
+	cfg := failClosedConfig(t)
+	cfg.BuiltinTools = []BuiltinTool{
+		{Tool: staticTool{name: "memory"}},
+		{
+			Tool:      staticTool{name: "email"},
+			Available: func(context.Context, RunnerParams) (bool, error) { return false, nil },
+		},
+	}
+	cfg.ToolOverrideFetcher = func(context.Context, string, string) ([]ToolOverride, error) {
+		return []ToolOverride{
+			{ToolName: "recally_digest", Scope: ToolOverrideScopeUser, Enabled: false},
+			{ToolName: "memory", Scope: ToolOverrideScopeUser, Enabled: false},
+			{ToolName: "email", Scope: ToolOverrideScopeUser, Enabled: false},
+			{ToolName: "bash", Scope: ToolOverrideScopeUser, Enabled: false},
+		}, nil
+	}
+
+	reg, _, _, err := buildToolRegistry(context.Background(), cfg, &fakeSession{alive: true}, nil, ai.Model{}, "")
+	if err != nil {
+		t.Fatalf("buildToolRegistry: %v", err)
+	}
+	if reg.Has("memory") {
+		t.Fatal("the override should still have disabled memory")
+	}
+	if !strings.Contains(logs.String(), "recally_digest") {
+		t.Fatalf("orphan override row should be logged, got %s", logs.String())
+	}
+	// A disabled tool, a tool this run cannot use, and a core name are all known
+	// names: none of them is a stale row.
+	for _, quiet := range []string{"memory", "email", "bash"} {
+		if strings.Contains(logs.String(), "tool="+quiet) {
+			t.Fatalf("%s is a known tool and must not be reported as unknown: %s", quiet, logs.String())
+		}
+	}
+}
+
+// Per-run exclusion lists come from callers with their own copy of the tool
+// names; a name that has since gone away hides nothing and must not fail the run.
+func TestFilterRunnerToolsWarnsOnUnknownExclusion(t *testing.T) {
+	logs := captureLogs(t)
+	reg := pkgtools.NewRegistry()
+	if err := reg.Register(staticTool{name: "goal"}); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	_, defs, err := filterRunnerTools(reg, []string{"goal_list"})
+	if err != nil {
+		t.Fatalf("filterRunnerTools: %v", err)
+	}
+	if len(defs) != 1 || defs[0].Name != "goal" {
+		t.Fatalf("defs = %#v, want the registered goal tool", defs)
+	}
+	if !strings.Contains(logs.String(), "goal_list") {
+		t.Fatalf("unknown exclusion should be logged, got %s", logs.String())
+	}
+}

--- a/internal/server/agent_tools.go
+++ b/internal/server/agent_tools.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"sort"
 
@@ -136,7 +137,16 @@ func (s *Server) agentTools(ctx context.Context, agentID string) ([]types.AgentT
 		if agent.IsCoreToolName(def.Name) {
 			continue
 		}
-		defaultEnabled := entry.Available == nil || entry.Available(ctx, params)
+		defaultEnabled := true
+		if entry.Available != nil {
+			// Surfacing the last known state would show a tool as enabled while the
+			// runner refuses to build it. Fail the whole catalog instead.
+			available, err := entry.Available(ctx, params)
+			if err != nil {
+				return nil, fmt.Errorf("resolve availability for tool %q: %w", def.Name, err)
+			}
+			defaultEnabled = available
+		}
 		decision := agent.ResolveToolOverride(defaultEnabled, def.Name, overrides)
 		items = append(items, types.AgentTool{
 			Name: def.Name, Description: def.Description,

--- a/internal/server/agent_tools_availability_test.go
+++ b/internal/server/agent_tools_availability_test.go
@@ -1,8 +1,11 @@
 package server_test
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/CherryHQ/stella/api/types"
@@ -79,5 +82,30 @@ func TestListAgentToolsExposesOnlyCurrentCoreCatalog(t *testing.T) {
 		if core[i].Name != want || !core[i].Enabled {
 			t.Fatalf("core[%d] = %#v, want enabled %q", i, core[i], want)
 		}
+	}
+}
+
+// An availability probe that cannot answer must not leave the catalog showing
+// the tool's last known state: the operator would toggle a row the runner will
+// refuse to build. Fail the request instead.
+func TestListAgentToolsFailsWhenAvailabilityIsUnknown(t *testing.T) {
+	env := setupAdmin(t)
+	_, sessionID := newNonAdmin(t, env, "availability-error-user")
+	agentID := createAgentAsUser(t, env, sessionID, "availability-error-agent")
+	env.rebuild(t, func(deps *server.Deps) {
+		deps.BuiltinTools = []agent.BuiltinTool{{
+			Tool: fakeManagedTool{name: "email"},
+			Available: func(context.Context, agent.RunnerParams) (bool, error) {
+				return false, errors.New("vault unreachable")
+			},
+		}}
+	})
+
+	rr := doRequestWithSession(t, env.srv, sessionID, http.MethodGet, "/api/agents/"+agentID+"/tools", nil)
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("list tools status = %d, want %d (body: %s)", rr.Code, http.StatusInternalServerError, rr.Body.String())
+	}
+	if body := rr.Body.String(); strings.Contains(body, "\"email\"") {
+		t.Fatalf("stale tool state must not be served on a failed probe: %s", body)
 	}
 }

--- a/internal/skills/tool.go
+++ b/internal/skills/tool.go
@@ -178,9 +178,13 @@ func (t *Tool) viewContext(ctx context.Context) ViewContext {
 	}
 }
 
+// ToolName is the model-facing name of the skills tool. Exported so callers
+// that record or match the tool surface do not repeat the literal.
+const ToolName = "skills"
+
 func pkgskillsToolDefinition() tools.Definition {
 	return tools.Definition{
-		Name:        "skills",
+		Name:        ToolName,
 		Description: "Search installed visible skills by task query, then load one selected skill's exact content revision.",
 		InputSchema: skillsInputSchema,
 	}

--- a/pkg/agent/helpers_test.go
+++ b/pkg/agent/helpers_test.go
@@ -24,16 +24,19 @@ func (s *simpleTool) Execute(_ context.Context, _ map[string]any) (string, error
 	return s.result, s.err
 }
 
-func newTestRegistry(ts ...tools.Tool) *tools.Registry {
+func newTestRegistry(t *testing.T, ts ...tools.Tool) *tools.Registry {
+	t.Helper()
 	r := tools.NewRegistry()
-	for _, t := range ts {
-		r.Register(t)
+	for _, tool := range ts {
+		if err := r.Register(tool); err != nil {
+			t.Fatalf("register %s: %v", tool.Definition().Name, err)
+		}
 	}
 	return r
 }
 
 func TestToolSetFromRegistry(t *testing.T) {
-	reg := newTestRegistry(&simpleTool{name: "echo", result: "pong"})
+	reg := newTestRegistry(t, &simpleTool{name: "echo", result: "pong"})
 	set := ToolSetFromRegistry(reg)
 
 	if len(set) != 1 {
@@ -55,7 +58,7 @@ func TestToolSetFromRegistry(t *testing.T) {
 }
 
 func TestToolSetFromRegistryFiltered_Success(t *testing.T) {
-	reg := newTestRegistry(
+	reg := newTestRegistry(t,
 		&simpleTool{name: "tool_a", result: "a"},
 		&simpleTool{name: "tool_b", result: "b"},
 	)
@@ -79,7 +82,7 @@ func TestToolSetFromRegistryFiltered_Success(t *testing.T) {
 }
 
 func TestToolSetFromRegistryFiltered_UnknownTool(t *testing.T) {
-	reg := newTestRegistry(&simpleTool{name: "foo"})
+	reg := newTestRegistry(t, &simpleTool{name: "foo"})
 
 	_, _, err := ToolSetFromRegistryFiltered(reg, []string{"nonexistent"})
 	if err == nil {

--- a/pkg/tools/registry.go
+++ b/pkg/tools/registry.go
@@ -34,9 +34,17 @@ func (r *Registry) BuiltinNames() []string {
 	return names
 }
 
-// Register adds a tool to the registry.
-func (r *Registry) Register(t Tool) {
-	r.tools[t.Definition().Name] = t
+// Register adds a tool to the registry. A name already taken is refused rather
+// than overwritten: silently replacing a tool changes which implementation (and
+// which sandbox policy) a model call reaches, and the caller that assembled the
+// registry is the only place that knows which source should win.
+func (r *Registry) Register(t Tool) error {
+	name := t.Definition().Name
+	if _, taken := r.tools[name]; taken {
+		return fmt.Errorf("tools: tool %q is already registered", name)
+	}
+	r.tools[name] = t
+	return nil
 }
 
 // Definitions returns all tool definitions in stable name order for passing to the LLM.

--- a/pkg/tools/registry_test.go
+++ b/pkg/tools/registry_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 )
 
@@ -43,9 +44,16 @@ func TestNewRegistry(t *testing.T) {
 	}
 }
 
+func mustRegister(t *testing.T, r *Registry, tool Tool) {
+	t.Helper()
+	if err := r.Register(tool); err != nil {
+		t.Fatalf("register %s: %v", tool.Definition().Name, err)
+	}
+}
+
 func TestRegistry_RegisterAndHas(t *testing.T) {
 	r := NewRegistry()
-	r.Register(&mockTool{name: "foo"})
+	mustRegister(t, r, &mockTool{name: "foo"})
 	if !r.Has("foo") {
 		t.Error("expected registry to have 'foo'")
 	}
@@ -65,7 +73,7 @@ func TestRegistry_DefinitionsStableOrder(t *testing.T) {
 	for _, order := range registrationOrders {
 		r := NewRegistry()
 		for _, name := range order {
-			r.Register(&mockTool{name: name})
+			mustRegister(t, r, &mockTool{name: name})
 		}
 
 		// Materialize repeatedly so map iteration can never leak into provider-facing order.
@@ -95,8 +103,8 @@ func TestRegistry_DefinitionsStableOrder(t *testing.T) {
 
 func TestRegistry_BuiltinNames(t *testing.T) {
 	r := NewRegistry()
-	r.Register(&mockTool{name: "x"})
-	r.Register(&mockTool{name: "y"})
+	mustRegister(t, r, &mockTool{name: "x"})
+	mustRegister(t, r, &mockTool{name: "y"})
 	names := r.BuiltinNames()
 	if len(names) != 2 {
 		t.Errorf("expected 2 names, got %d", len(names))
@@ -105,7 +113,7 @@ func TestRegistry_BuiltinNames(t *testing.T) {
 
 func TestRegistry_Execute(t *testing.T) {
 	r := NewRegistry()
-	r.Register(&mockTool{name: "greet", result: "hello"})
+	mustRegister(t, r, &mockTool{name: "greet", result: "hello"})
 
 	result, err := r.Execute(context.Background(), "greet", nil)
 	if err != nil {
@@ -127,7 +135,7 @@ func TestRegistry_Execute_UnknownTool(t *testing.T) {
 func TestRegistry_Execute_ToolError(t *testing.T) {
 	toolErr := errors.New("tool failed")
 	r := NewRegistry()
-	r.Register(&mockTool{name: "broken", err: toolErr})
+	mustRegister(t, r, &mockTool{name: "broken", err: toolErr})
 
 	_, err := r.Execute(context.Background(), "broken", nil)
 	if !errors.Is(err, toolErr) {
@@ -138,8 +146,8 @@ func TestRegistry_Execute_ToolError(t *testing.T) {
 func TestRegistry_Close(t *testing.T) {
 	r := NewRegistry()
 	ct := &mockCloseableTool{mockTool: mockTool{name: "closeable"}}
-	r.Register(ct)
-	r.Register(&mockTool{name: "plain"})
+	mustRegister(t, r, ct)
+	mustRegister(t, r, &mockTool{name: "plain"})
 
 	if err := r.Close(); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -153,10 +161,33 @@ func TestRegistry_Close_Error(t *testing.T) {
 	r := NewRegistry()
 	closeErr := errors.New("close error")
 	ct := &mockCloseableTool{mockTool: mockTool{name: "ct"}, closeErr: closeErr}
-	r.Register(ct)
+	mustRegister(t, r, ct)
 
 	err := r.Close()
 	if !errors.Is(err, closeErr) {
 		t.Errorf("expected close error, got %v", err)
+	}
+}
+
+// A second tool answering to a live name is refused, and the tool already in the
+// registry keeps the name: a silent swap would move calls to a different
+// implementation without any caller noticing.
+func TestRegistry_RegisterRejectsDuplicateName(t *testing.T) {
+	r := NewRegistry()
+	mustRegister(t, r, &mockTool{name: "share", result: "first"})
+
+	err := r.Register(&mockTool{name: "share", result: "second"})
+	if err == nil {
+		t.Fatal("expected duplicate registration to be refused")
+	}
+	if !strings.Contains(err.Error(), "share") {
+		t.Fatalf("error should name the tool, got %v", err)
+	}
+	result, execErr := r.Execute(context.Background(), "share", nil)
+	if execErr != nil {
+		t.Fatalf("execute: %v", execErr)
+	}
+	if result != "first" {
+		t.Fatalf("incumbent tool should keep the name, got %q", result)
 	}
 }


### PR DESCRIPTION
## What

Three tool-visibility paths that answered "I don't know" with a guess now fail the runner build instead, so a transient dependency outage can no longer be cached as a wrong tool set for the life of a session. No tool name, schema, override semantic, or UI changes.

Error paths, before → after:

| Path | Before | After |
| --- | --- | --- |
| Builtin `Available` predicate (vault / oauth-status query fails) | `func(ctx, params) bool` had no way to say "unknown"; `emailToolAvailable` and `oauthToolAvailable` returned `true` on a failed query, mounting the tool | `func(ctx, params) (bool, error)`; the error fails `buildToolRegistry`, the caller retries |
| `ToolOverrideFetcher` fails | `slog.Warn` + fall back to default visibility, i.e. every tool an administrator had disabled became visible | fails `buildToolRegistry`; no runner is created, nothing is cached |
| `tools.Registry.Register` name collision | silently overwrote the incumbent tool, so calls reached an implementation nobody chose | returns an error; `buildToolRegistry` fails and names both sources (`builtin` / `per-run` / `plugin` / `mcp` / `core`) |
| `GET /api/agents/{id}/tools` with a failing `Available` | showed the tool's last computed `enabled` state | 500; no stale row is served |
| Override row naming an unknown tool | silent | `slog.Warn`, build continues |
| Per-run `excluded_tools` naming an unregistered tool | silent | `slog.Warn`, run continues |

## Why

Prerequisite safety fix for the action-split series (#1173): splitting one tool name into N multiplies the number of rows the visibility layer resolves, so the layer has to be trustworthy before the names move. It stands on its own and ships independently of the split.

A runner is built once and its registry is fixed for the session. That makes a wrong answer during construction durable: a failed vault query used to mount a tool that can send mail on the user's behalf, and a failed override fetch used to hand the model the whole default tool set including everything an administrator had switched off. Failing the build is recoverable (the caller retries against live dependencies); a cached wrong answer is not.

Stale data is deliberately kept non-fatal. An override row or an exclusion list naming a tool this deployment no longer has is a data problem, not a fault; failing there would lock a user out of a working agent over a leftover row. Those two paths get a warning instead.

## How

- `agent.BuiltinTool.Available` is now `func(context.Context, RunnerParams) (bool, error)`. All implementations follow: `agent.BuiltinToolAvailable`, `libraryToolAvailable`, `emailToolAvailable`, `oauthToolAvailable`, the session-tool closure in `commands.go`. `emailToolAvailable` keeps `pgx.ErrNoRows` as a genuine "not configured" (`false, nil`) and reports every other error.
- `buildToolRegistry` fails on an `Available` error, on a `ToolOverrideFetcher` error, and on a duplicate non-core name. Non-core candidates now carry their source so a collision error names both sides.
- `tools.Registry.Register` returns an error rather than overwriting. **Chose error over panic** (the card allowed either): the registry is assembled per runner from user-controlled inputs (plugins, MCP servers), so a collision must fail one runner build, not the process. The incumbent keeps the name.
- Orphan-override warning is computed against every name this runner could have served, not only the ones it registered, so a tool that an override legitimately disabled, one that `Available` excluded, and a reserved core name are all silent.
- `internal/server/agent_tools.go` propagates the `Available` error; the existing `writeInternalError` turns it into a 500.

Name ownership is settled across all candidates **before** overrides are consulted, so a plugin claiming a builtin's name fails the build immediately instead of lying dormant behind a disabled incumbent and detonating the day an operator re-enables it. The settle pass seeds itself with every builtin the deployment ships, not only the ones a given run can use: otherwise a plugin could hold `email` on every run without `EMAIL_CONFIG` and collide only once the vault entry appears.

Cancellation outranks both hard-failure branches. `ctx.Err()` is checked first, so a closed pool under a cancelled run is reported as `context.Canceled` rather than as a dependency that failed to answer — a caller must not retry a build nobody is waiting for.

The builtin tool assembly moved out of the middle of `runCommands` into `newBuiltinTools(builtinToolDeps)` in `cmd/stellad/builtin_tools.go`. Same tools, same order; the point is that the list a deployment puts in front of the model is now enumerable by a test (see the golden below).

Deliberate limits:
- The orphan-override warning fires once per runner build per stale row, and a row for a tool belonging to a currently-disabled plugin counts as stale. That is one line per session, not per turn.
- A plugin or MCP tool colliding with a builtin name is now a hard runner-build failure rather than a silent override. No such collision exists in-tree (`webfetch` vs. the builtin set was checked); this is the intended fail-closed behavior.

### Known limitation: a scheduled one-time job can be retired by a transient outage

`schedJobWorker.Work` calls `executeSingleRun` and returns `nil` regardless of the run's outcome (`internal/scheduler/river.go:54-95`), River is configured with `MaxAttempts: 1` (`river.go:183,224`), and `executeSingleRun` retires a one-time job after it fires whether or not the run succeeded (`service.go:799`). A runner build is now a new failure point on that path: before this PR a transient `tool_override` fetch failure was swallowed with a warning, and now it fails the build, so the scheduled run fails and an `at` job is retired without a retry.

The window is narrow — the scheduler and the override store share the same database, so a database that is down does not fire the job in the first place; it takes a per-connection blip while the pool is otherwise healthy. Fixing it means giving the scheduler real retry semantics, which is a separate change with its own blast radius. **Follow-up issue candidate, deliberately not fixed here.**

## Test

- `mise run format && mise run build && mise run test` — all green (Go suite + 31 web test files / 284 tests).
- System suite — `go test -tags system -count=5 -timeout 15m ./test/system/... -v` on the final commit: **green, `ok github.com/CherryHQ/stella/test/system 403.857s`, `grep -- '--- FAIL'` returns nothing across all 5 iterations** (110 `--- PASS`, macOS darwin/arm64, embedded PostgreSQL).
  - Earlier in the branch's history one `mise run system-test` run failed without its failing test being captured. It has not reproduced in the nine runs since, including this 5-iteration sweep, so it is recorded as an unattributed flake rather than a known defect. If it resurfaces in CI, the new hard-failure paths in `buildToolRegistry` are the first place to look.
- `mise run generate:check` — green on the committed tree (no generated-file drift).
- New tests:
  - `internal/agent/tool_visibility_failclosed_test.go`: availability error fails the build and wraps the cause; override-fetch error fails the build; duplicate non-core name fails the build naming both sources; a plugin grabbing a *disabled* builtin's name still fails the build; a plugin grabbing an *unavailable* builtin's name still fails the build; a cancelled run reports `context.Canceled` from both branches and logs no visibility fault; **after an outage clears, a fresh build sees live state** — the retry mounts the recovered tool and applies the override the failed fetch would have missed, which is the load-bearing assumption behind failing closed; orphan override row warns while a disabled/unavailable/core name stays silent; unknown per-run exclusion warns and does not fail.
  - `cmd/stellad/builtin_tools_test.go`: golden list of the tool names a default deployment puts in front of the model (core + skills + every builtin, 26 names). It is the record the action-split work has to diff against, so a rename or an added tool shows up in review rather than in production. The skills entry reads `skillstool.ToolName`, newly exported, instead of repeating the literal.
  - `internal/agent/runtime/runner_cache_test.go`: pins the contract this whole PR leans on — a failed build drops the session entry and remembers nothing, so the next turn reaches the factory again instead of replaying a cached failure.
  - `pkg/tools/registry_test.go`: duplicate `Register` is refused and the incumbent keeps the name.
  - `internal/server/agent_tools_availability_test.go`: catalog returns 500 and does not serve the stale row when `Available` fails.
  - `cmd/stellad/tool_availability_test.go`: email and oauth predicates report lookup failures instead of defaulting (the old `FailsOpen` assertions are inverted and renamed).

## Refs

Refs #1173 — prerequisite safety fix for the union-tool action split; independently shippable.

## Checklist

- [x] The PR links a GitHub issue, or states why the fix is small enough not to need one.
- [x] I added or updated focused tests for changed non-trivial behavior, or explained why none are needed.
- [x] I updated relevant English and Chinese documentation, or no documentation change is needed. — no doc change needed: no user-facing tool, API contract, config, or command changes; only error-path behavior behind existing surfaces.
- [x] I ran `mise run format && mise run build && mise run test`.
- [x] If this changes agent behavior (tools, prompts, the runner loop): I included eval evidence with both jobs, commits, tier, k, host, and model, or stated why it is not applicable. — **not applicable.** The tool set on the success path is byte-identical; only error paths change. Harbor exercises `bash` only and has no builtin-tool coverage, so no eval score can speak to this change, and none is cited.
- [x] If the change touches a surface no eval task exercises (pixel understanding, document extraction, CRLF fidelity, non-UTF-8, binary handling): I said so, and named the tests that cover it instead. — builtin-tool visibility has no eval coverage; the Go tests listed under **Test** cover it instead.
- [x] Any earlier measurement this PR invalidates is marked superseded with its reason, not deleted. — none exists.

## Feishu Task

- [剩余联合工具按动作拆分为独立工具](https://mcnnox2fhjfq.feishu.cn/record/R27UrMuoyeLRnicaRilcJtxunUe) (#1173)
