### PR TITLE
🐛 fix(system-test): repair the three journeys that went red under Code Mode and per-media baselines

### DIFF
--- a/test/system/fake_anthropic_test.go
+++ b/test/system/fake_anthropic_test.go
@@ -30,14 +30,15 @@ import (
 //     enqueueTool (a tool-using turn is scripted as the call plus the text that
 //     ends the turn once the tool result comes back).
 //   - Goal (Phase 2): responses keyed by the goal_control action the server
-//     advertises in the request's tool schema (decompose/submit), matched on
-//     that stable structural field rather than arrival order — because a Goal
-//     attempt's agent tool loop makes a racy tool-result follow-up call whose
-//     arrival is not deterministic. See enqueueGoalControl.
+//     advertises (decompose/submit), matched on that stable structural field
+//     rather than arrival order — because a Goal attempt's agent tool loop makes
+//     a racy tool-result follow-up call whose arrival is not deterministic. See
+//     enqueueGoalControl.
 //
-// It never branches on prompt prose; only stable request fields (model, tool
-// names, the goal_control action enum) drive it, so ordinary prompt edits can
-// never turn into a system-test failure.
+// It never branches on prompt prose; only stable structural fields (model, tool
+// names, the goal_control action enum, and the fake's own marker echoed back in
+// a tool result) drive it, so ordinary prompt edits can never turn into a
+// system-test failure.
 type fakeAnthropic struct {
 	t      *testing.T
 	server *httptest.Server
@@ -50,10 +51,10 @@ type fakeAnthropic struct {
 	// was said must not also assert that nothing further was ever asked.
 	modelTrailing map[string]fakeResponse
 	reqs          []fakeRequest // every request received, in arrival order
-	// controls holds Phase 2 responses keyed by goal_control action variant
-	// ("decompose"/"submit"). Each is served once (the stage's terminal tool_use);
-	// a later same-variant request is the racy trailing turn and gets a benign
-	// end_turn text so the agent loop terminates without consuming another stage.
+	// controls holds Phase 2 goal_control arguments keyed by action variant
+	// ("decompose"/"submit"). The fake serves one script carrying every stage and
+	// lets the attempt's own catalog pick; a stage is marked served when its
+	// marker comes back in the code tool result. See enqueueGoalControl.
 	controls map[string]*controlResponse
 	// errScript, when set, makes the fake answer every request with the same HTTP
 	// error instead of an SSE turn. It is sticky (not FIFO-popped) on purpose: the
@@ -89,10 +90,132 @@ func (g *turnGate) Release() { close(g.release) }
 // (and fails the test) well before teardown would kill the process group.
 const gateBackstop = 30 * time.Second
 
-// goalTrailingReply is the benign end_turn text served for the tool-result
-// follow-up turn of an already-satisfied goal_control stage. Its only job is to
-// end the agent loop cleanly; the terminal action was already recorded.
+// goalTrailingReply is the benign end_turn text served once a goal turn's code
+// call has come back. Its only job is to end the agent loop cleanly; the
+// terminal action was already recorded inside that call.
 const goalTrailingReply = "acknowledged"
+
+// The goal scripts report back through these markers. They are the fake's own
+// output echoed to it in the next request's tool_result, not prompt prose: the
+// fake reads only what it planted.
+const (
+	goalActionsMarker = "stella-goal-actions:"
+	goalStageMarker   = "stella-goal-stage:"
+	goalErrorMarker   = "stella-goal-error:"
+)
+
+// Code Mode is the only tool path (#1182), so goal_control is a cold tool: it no
+// longer appears in the request's tool list, and a decomposition turn is
+// byte-identical to an execution turn. The stage discriminator did not
+// disappear, it moved — the per-attempt goal_control schema now reaches the
+// model through the code catalog — so the fake fetches it from there in two
+// steps and keeps matching on exactly the field it always did.
+//
+// goalProbeScript is step one: read the action enum out of the catalog and hand
+// it back. Nothing terminal happens, so the attempt is guaranteed to ask again.
+func goalProbeScript() (string, error) {
+	return codeCallArguments(fmt.Sprintf(`
+let schema;
+try {
+  schema = tools.describe("goal_control").inputSchema;
+} catch (error) {
+  return %q + "describe goal_control: " + String(error);
+}
+const action = schema && schema.properties && schema.properties.action;
+return %q + (((action && action.enum) || []).join(","));
+`, goalErrorMarker, goalActionsMarker))
+}
+
+// goalStageScript is step two: run the stage the probe identified. The attempt
+// ends on this call, so the marker it returns is only ever read when the agent
+// loop happens to take one more turn — the fake has already recorded the stage
+// by serving this script.
+func goalStageScript(action, args string) (string, error) {
+	return codeCallArguments(fmt.Sprintf(`
+try {
+  await tools.invoke("goal_control", %s);
+} catch (error) {
+  return %q + "goal_control %s: " + String(error);
+}
+return %q;
+`, args, goalErrorMarker, action, goalStageMarker+action))
+}
+
+func codeCallArguments(source string) (string, error) {
+	args, err := json.Marshal(map[string]string{"code": source})
+	if err != nil {
+		return "", fmt.Errorf("marshal code arguments: %w", err)
+	}
+	return string(args), nil
+}
+
+// goalTurn is what one request tells the fake about a Goal run: whether it is
+// answering a code call, and which of the fake's own markers came back in it.
+type goalTurn struct {
+	continuation bool
+	// actions is the goal_control action enum the probe read out of this
+	// attempt's catalog, set only on the turn answering the probe.
+	actions []string
+	// stage is the action a stage script reported running, set only on a trailing
+	// turn after that script.
+	stage string
+	// failure is a script-reported error, or the reason the fake could not read
+	// its own marker back.
+	failure string
+}
+
+// parseGoalTurn reads the fake's own marker out of the request's last message.
+// Only the last message counts: a session's later turns still carry the marker
+// in their history, and each marker must drive exactly one decision.
+func parseGoalTurn(messages []string, continuation bool) goalTurn {
+	turn := goalTurn{continuation: continuation}
+	if !continuation || len(messages) == 0 {
+		return turn
+	}
+	last := messages[len(messages)-1]
+	if value, ok := markerValue(last, goalErrorMarker); ok {
+		turn.failure = value
+		return turn
+	}
+	if value, ok := markerValue(last, goalActionsMarker); ok {
+		if value != "" {
+			turn.actions = strings.Split(value, ",")
+		}
+		return turn
+	}
+	if value, ok := markerValue(last, goalStageMarker); ok {
+		turn.stage = value
+		return turn
+	}
+	turn.failure = "code result carried none of the fake's goal markers: " + last
+	return turn
+}
+
+// markerValue extracts one marker's payload from a flattened message. The code
+// result is a JSON string, so the value ends at the closing quote.
+func markerValue(text, marker string) (string, bool) {
+	_, rest, ok := strings.Cut(text, marker)
+	if !ok {
+		return "", false
+	}
+	if j := strings.IndexAny(rest, "\"\n"); j >= 0 {
+		rest = rest[:j]
+	}
+	return rest, true
+}
+
+// nonFailAction returns the goal_control stage discriminator: the first action
+// enum value that is not "fail" (decompose/submit/verdict). The action set the
+// server advertises distinguishes the decomposition, execution, and review
+// stages even though the tool name is always "goal_control".
+func nonFailAction(enum []string) string {
+	for _, a := range enum {
+		if a != "fail" {
+			return a
+		}
+	}
+	return ""
+}
 
 // fakeResponse is one scripted assistant turn. Exactly one shape is set: a
 // plain text reply, or a single tool call. Keeping the two explicit (rather
@@ -115,12 +238,16 @@ type fakeResponse struct {
 	// text-delta (text), blocks on the gate, then flushes the remainder (text2).
 	gate  *turnGate
 	text2 string
+
+	// goalStage names the goal_control stage this response runs, for the request
+	// log. It is not part of the SSE turn.
+	goalStage string
 }
 
-// controlResponse is a goal_control stage's scripted tool_use plus whether it
-// has already been served.
+// controlResponse is one goal_control stage's scripted input JSON plus whether
+// the attempt that advertised that action has already run it.
 type controlResponse struct {
-	resp   fakeResponse
+	args   string
 	served bool
 }
 
@@ -135,10 +262,10 @@ type fakeRequest struct {
 	// APIKey is the Anthropic x-api-key header. Tests use only explicit,
 	// non-production fixture values and never print it from generic diagnostics.
 	APIKey string
-	// GoalControl is the non-fail goal_control action the request advertised
-	// ("decompose"/"submit"/"verdict"), or "" when the request carries no
-	// goal_control tool. It is the Goal-stage discriminator.
-	GoalControl string
+	// GoalStage is the goal_control action the fake answered this request with,
+	// selected from the action enum the attempt advertised. It is "" for the probe
+	// and trailing turns of a Goal run, and for every non-Goal request.
+	GoalStage string
 }
 
 type fakeImage struct {
@@ -232,8 +359,8 @@ func TestFakeAnthropicModelScriptsDoNotConsumeFIFO(t *testing.T) {
 	f.enqueueText("fifo")
 	f.enqueueTextForModel("agent-a", "a")
 	f.mu.Lock()
-	a, okA := f.selectResponse("agent-a", "", false)
-	b, okB := f.selectResponse("agent-b", "", false)
+	a, okA := f.selectResponse("agent-a", goalTurn{})
+	b, okB := f.selectResponse("agent-b", goalTurn{})
 	f.mu.Unlock()
 	if !okA || !okB || a.text != "a" || b.text != "fifo" {
 		t.Fatalf("model/FIFO responses = %q/%q", a.text, b.text)
@@ -246,21 +373,32 @@ func (f *fakeAnthropic) enqueueTool(id, name, args string) {
 	f.scripts = append(f.scripts, fakeResponse{toolID: id, toolName: name, toolArgs: args})
 }
 
-// enqueueGoalControl scripts the tool_use reply for one goal_control stage,
-// matched by the action enum the server advertises in the request's goal_control
-// tool schema — not by prompt text or arrival order. args is the full
-// goal_control input JSON, e.g. `{"action":"submit","summary":"done"}`.
+// enqueueGoalControl scripts one goal_control stage, selected by the action enum
+// the server advertises to that attempt — not by prompt text or arrival order.
+// args is the full goal_control input JSON, e.g.
+// `{"action":"submit","summary":"done"}`. The selection now happens inside the
+// attempt's own code catalog; see goalCodeScript.
 func (f *fakeAnthropic) enqueueGoalControl(action, args string) {
+	if !json.Valid([]byte(args)) {
+		f.t.Fatalf("fake anthropic: goal_control %q arguments are not valid JSON: %s", action, args)
+	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if f.controls == nil {
 		f.controls = make(map[string]*controlResponse)
 	}
-	f.controls[action] = &controlResponse{resp: fakeResponse{
-		toolID:   "toolu_" + action,
-		toolName: "goal_control",
-		toolArgs: args,
-	}}
+	f.controls[action] = &controlResponse{args: args}
+}
+
+// goalCodeCall wraps one built script as the code tool_use the fake serves.
+// Called under f.mu.
+func (f *fakeAnthropic) goalCodeCall(id string, build func() (string, error)) (fakeResponse, bool) {
+	args, err := build()
+	if err != nil {
+		f.t.Errorf("fake anthropic: build goal code call: %v", err)
+		return fakeResponse{}, false
+	}
+	return fakeResponse{toolID: id, toolName: "code", toolArgs: args}, true
 }
 
 // enqueueError makes the fake answer every subsequent request with the given
@@ -334,14 +472,17 @@ func (f *fakeAnthropic) handle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	model, messages, images, toolNames, control, continuation := parseMessagesRequest(f.t, r)
+	model, messages, images, toolNames, continuation := parseMessagesRequest(f.t, r)
+	goal := parseGoalTurn(messages, continuation)
 
 	f.mu.Lock()
+	index := len(f.reqs)
 	f.reqs = append(f.reqs, fakeRequest{
 		Model: model, Messages: messages, Images: images, ToolNames: toolNames,
-		APIKey: r.Header.Get("x-api-key"), GoalControl: control,
+		APIKey: r.Header.Get("x-api-key"),
 	})
-	resp, ok := f.selectResponse(model, control, continuation)
+	resp, ok := f.selectResponse(model, goal)
+	f.reqs[index].GoalStage = resp.goalStage
 	f.mu.Unlock()
 	if !ok {
 		http.Error(w, "no scripted response", http.StatusInternalServerError)
@@ -401,10 +542,11 @@ func (f *fakeAnthropic) writeFrames(w http.ResponseWriter, flusher http.Flusher,
 }
 
 // selectResponse picks the response for one request under f.mu. Goal mode (any
-// enqueued goal_control stage) matches on the request's goal_control action;
-// otherwise the Phase 1 FIFO applies. It records a test failure and returns
-// ok=false for any request it cannot answer.
-func (f *fakeAnthropic) selectResponse(model, control string, continuation bool) (fakeResponse, bool) {
+// enqueued goal_control stage) hands every fresh turn the stage-selecting code
+// call and closes the turn once its marker comes back; otherwise the Phase 1
+// FIFO applies. It records a test failure and returns ok=false for any request
+// it cannot answer.
+func (f *fakeAnthropic) selectResponse(model string, goal goalTurn) (fakeResponse, bool) {
 	// A sticky provider error answers every request (including SDK retries) so a
 	// journey testing the failure path never trips the unscripted-request guard.
 	if f.errScript != nil {
@@ -413,19 +555,7 @@ func (f *fakeAnthropic) selectResponse(model, control string, continuation bool)
 	}
 
 	if len(f.controls) > 0 {
-		cs := f.controls[control]
-		switch {
-		case cs != nil && !cs.served:
-			cs.served = true
-			return cs.resp, true
-		case cs != nil:
-			// The stage's terminal action was already recorded; this is the racy
-			// tool-result follow-up turn. End the loop with a benign reply.
-			return fakeResponse{text: goalTrailingReply}, true
-		default:
-			f.t.Errorf("fake anthropic: unscripted goal request (goal_control=%q, model=%q); no stage was enqueued for it", control, model)
-			return fakeResponse{}, false
-		}
+		return f.selectGoalResponse(model, goal)
 	}
 
 	if scripts := f.modelScripts[model]; len(scripts) > 0 {
@@ -443,6 +573,45 @@ func (f *fakeAnthropic) selectResponse(model, control string, continuation bool)
 	resp := f.scripts[0]
 	f.scripts = f.scripts[1:]
 	return resp, true
+}
+
+// selectGoalResponse answers one Goal turn. Called under f.mu.
+//
+//   - A fresh turn gets the probe: nothing terminal has run, so the attempt is
+//     guaranteed to come back with its action enum.
+//   - The turn answering the probe names the stage; the fake serves that stage's
+//     goal_control call and records it as requested.
+//   - The turn answering a stage script is the racy trailing turn: the terminal
+//     action is already recorded, so a benign end_turn ends the loop without
+//     consuming another stage.
+func (f *fakeAnthropic) selectGoalResponse(model string, goal goalTurn) (fakeResponse, bool) {
+	if !goal.continuation {
+		return f.goalCodeCall("toolu_goal_probe", goalProbeScript)
+	}
+	if goal.failure != "" {
+		f.t.Errorf("fake anthropic: goal code call failed (model=%q): %s", model, goal.failure)
+		return fakeResponse{}, false
+	}
+	if goal.stage != "" {
+		return fakeResponse{text: goalTrailingReply}, true
+	}
+	action := nonFailAction(goal.actions)
+	cs := f.controls[action]
+	if cs == nil {
+		f.t.Errorf("fake anthropic: goal attempt advertised actions %v (model=%q); no stage was enqueued for %q", goal.actions, model, action)
+		return fakeResponse{}, false
+	}
+	if cs.served {
+		// The same stage asked twice: its terminal action is already recorded, so
+		// running it again would fail inside goal_control. End the loop instead.
+		return fakeResponse{text: goalTrailingReply}, true
+	}
+	cs.served = true
+	resp, ok := f.goalCodeCall("toolu_goal_"+action, func() (string, error) {
+		return goalStageScript(action, cs.args)
+	})
+	resp.goalStage = action
+	return resp, ok
 }
 
 // frames renders the scripted response as the ordered SSE event sequence the
@@ -549,16 +718,15 @@ func (r fakeResponse) textDeltaFrame() string {
 }
 
 // parseMessagesRequest extracts the stable fields the fake is allowed to record
-// and match on: the model, the tool names, and the non-fail goal_control action
-// the request's tool schema advertises. A body it cannot parse is a real defect
-// (the system sent something the Anthropic API would reject), so it fails the
-// test rather than guessing.
-func parseMessagesRequest(t *testing.T, r *http.Request) (model string, messages []string, images []fakeImage, toolNames []string, goalControl string, continuation bool) {
+// and match on: the model, the tool names, and the message payloads. A body it
+// cannot parse is a real defect (the system sent something the Anthropic API
+// would reject), so it fails the test rather than guessing.
+func parseMessagesRequest(t *testing.T, r *http.Request) (model string, messages []string, images []fakeImage, toolNames []string, continuation bool) {
 	t.Helper()
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		t.Errorf("fake anthropic: read request body: %v", err)
-		return "", nil, nil, nil, "", false
+		return "", nil, nil, nil, false
 	}
 	var parsed struct {
 		Model    string `json:"model"`
@@ -566,19 +734,12 @@ func parseMessagesRequest(t *testing.T, r *http.Request) (model string, messages
 			Content json.RawMessage `json:"content"`
 		} `json:"messages"`
 		Tools []struct {
-			Name        string `json:"name"`
-			InputSchema struct {
-				Properties struct {
-					Action struct {
-						Enum []string `json:"enum"`
-					} `json:"action"`
-				} `json:"properties"`
-			} `json:"input_schema"`
+			Name string `json:"name"`
 		} `json:"tools"`
 	}
 	if err := json.Unmarshal(body, &parsed); err != nil {
 		t.Errorf("fake anthropic: request body is not valid Messages JSON: %v", err)
-		return "", nil, nil, nil, "", false
+		return "", nil, nil, nil, false
 	}
 	// Only the request that *answers* a tool call is a continuation. A session's
 	// later turns still carry that tool result in their history, so matching the
@@ -599,11 +760,8 @@ func parseMessagesRequest(t *testing.T, r *http.Request) (model string, messages
 	names := make([]string, 0, len(parsed.Tools))
 	for _, tool := range parsed.Tools {
 		names = append(names, tool.Name)
-		if tool.Name == "goal_control" {
-			goalControl = nonFailAction(tool.InputSchema.Properties.Action.Enum)
-		}
 	}
-	return parsed.Model, messages, images, names, goalControl, continuation
+	return parsed.Model, messages, images, names, continuation
 }
 
 // messagePayload extracts text and images from top-level message blocks and
@@ -657,17 +815,4 @@ func collectMessageBlocks(content json.RawMessage, text *strings.Builder, images
 		}
 	}
 	return true
-}
-
-// nonFailAction returns the goal_control stage discriminator: the first action
-// enum value that is not "fail" (decompose/submit/verdict). The action set the
-// server sends distinguishes the decomposition, execution, and review stages
-// even though the tool name is always "goal_control".
-func nonFailAction(enum []string) string {
-	for _, a := range enum {
-		if a != "fail" {
-			return a
-		}
-	}
-	return ""
 }

--- a/test/system/fake_anthropic_test.go
+++ b/test/system/fake_anthropic_test.go
@@ -52,9 +52,10 @@ type fakeAnthropic struct {
 	modelTrailing map[string]fakeResponse
 	reqs          []fakeRequest // every request received, in arrival order
 	// controls holds Phase 2 goal_control arguments keyed by action variant
-	// ("decompose"/"submit"). The fake serves one script carrying every stage and
-	// lets the attempt's own catalog pick; a stage is marked served when its
-	// marker comes back in the code tool result. See enqueueGoalControl.
+	// ("decompose"/"submit"). A stage is marked served the moment the fake emits
+	// its script, not when a marker comes back: the tool-result follow-up turn is
+	// racy, and in the measured run neither attempt took one, so waiting for it
+	// would leave decompose recorded as never requested. See enqueueGoalControl.
 	controls map[string]*controlResponse
 	// errScript, when set, makes the fake answer every request with the same HTTP
 	// error instead of an SSE turn. It is sticky (not FIFO-popped) on purpose: the
@@ -105,11 +106,12 @@ const (
 )
 
 // Code Mode is the only tool path (#1182), so goal_control is a cold tool: it no
-// longer appears in the request's tool list, and a decomposition turn is
-// byte-identical to an execution turn. The stage discriminator did not
-// disappear, it moved — the per-attempt goal_control schema now reaches the
-// model through the code catalog — so the fake fetches it from there in two
-// steps and keeps matching on exactly the field it always did.
+// longer appears in the request's tool list, and nothing in the provider-facing
+// tool surface tells a decomposition turn from an execution one. The prompts and
+// histories do differ, but those are prose the fake must never branch on. The
+// stage discriminator did not disappear, it moved — the per-attempt goal_control
+// schema now reaches the model through the code catalog — so the fake fetches it
+// from there in two steps and keeps matching on exactly the field it always did.
 //
 // goalProbeScript is step one: read the action enum out of the catalog and hand
 // it back. Nothing terminal happens, so the attempt is guaranteed to ask again.
@@ -127,9 +129,9 @@ return %q + (((action && action.enum) || []).join(","));
 }
 
 // goalStageScript is step two: run the stage the probe identified. The attempt
-// ends on this call, so the marker it returns is only ever read when the agent
-// loop happens to take one more turn — the fake has already recorded the stage
-// by serving this script.
+// ends on this call, so the marker it returns is read only if the agent loop
+// happens to take one more racy turn — which is why the fake records the stage
+// when it serves this script rather than when the marker comes back.
 func goalStageScript(action, args string) (string, error) {
 	return codeCallArguments(fmt.Sprintf(`
 try {
@@ -376,11 +378,20 @@ func (f *fakeAnthropic) enqueueTool(id, name, args string) {
 // enqueueGoalControl scripts one goal_control stage, selected by the action enum
 // the server advertises to that attempt — not by prompt text or arrival order.
 // args is the full goal_control input JSON, e.g.
-// `{"action":"submit","summary":"done"}`. The selection now happens inside the
-// attempt's own code catalog; see goalCodeScript.
+// `{"action":"submit","summary":"done"}`. The selection happens inside the
+// attempt's own code catalog; see goalProbeScript and goalStageScript.
 func (f *fakeAnthropic) enqueueGoalControl(action, args string) {
-	if !json.Valid([]byte(args)) {
+	var parsed struct {
+		Action string `json:"action"`
+	}
+	if err := json.Unmarshal([]byte(args), &parsed); err != nil {
 		f.t.Fatalf("fake anthropic: goal_control %q arguments are not valid JSON: %s", action, args)
+	}
+	// The key selects the stage and the body performs it; a mismatch would script
+	// one stage under another's name and only surface as a confusing goal_control
+	// rejection deep inside an attempt.
+	if parsed.Action != action {
+		f.t.Fatalf("fake anthropic: goal_control stage %q carries action %q", action, parsed.Action)
 	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -580,10 +591,12 @@ func (f *fakeAnthropic) selectResponse(model string, goal goalTurn) (fakeRespons
 //   - A fresh turn gets the probe: nothing terminal has run, so the attempt is
 //     guaranteed to come back with its action enum.
 //   - The turn answering the probe names the stage; the fake serves that stage's
-//     goal_control call and records it as requested.
-//   - The turn answering a stage script is the racy trailing turn: the terminal
-//     action is already recorded, so a benign end_turn ends the loop without
-//     consuming another stage.
+//     goal_control call and records it as requested right there. Recording on the
+//     serve is what makes this deterministic: a stage script ends the attempt, so
+//     whether its own marker ever comes back is up to the racy trailing turn.
+//   - A turn answering a stage script, when one happens, is that trailing turn:
+//     the terminal action is already recorded, so a benign end_turn ends the loop
+//     without consuming another stage.
 func (f *fakeAnthropic) selectGoalResponse(model string, goal goalTurn) (fakeResponse, bool) {
 	if !goal.continuation {
 		return f.goalCodeCall("toolu_goal_probe", goalProbeScript)

--- a/test/system/goal_test.go
+++ b/test/system/goal_test.go
@@ -33,10 +33,12 @@ import (
 //     auto-passes and the child goes done/accepted. rollupComposites then accepts
 //     the required-child-complete root.
 //
-// Only two model turns are scripted (decompose, submit), matched by the
-// goal_control action the server advertises rather than by arrival order,
-// because each attempt's agent tool loop may fire a racy tool-result follow-up
-// turn whose timing is not deterministic (see fake_anthropic_test.go).
+// Only two stages are scripted (decompose, submit), selected by the goal_control
+// action the server advertises to each attempt rather than by arrival order,
+// because an attempt's agent tool loop may fire a racy tool-result follow-up
+// turn whose timing is not deterministic. Under Code Mode that advertised action
+// reaches the model through the code catalog, so the selection happens inside
+// the scripted code call (see fake_anthropic_test.go).
 func (h *harness) testGoalLifecycle(t *testing.T) {
 	fake := newFakeAnthropic(t)
 
@@ -322,36 +324,40 @@ func (h *harness) assertGoalSessionsLive(t *testing.T, ctx context.Context, root
 }
 
 // assertGoalFakeRequests proves the model traffic matched the script: every
-// request the fake saw carried a scripted goal_control stage (no surprise
-// non-goal_control or unknown-variant call), and both scripted stages were
-// observed. That the two enqueued stages were consumed is enforced by the fake's
-// cleanup; this adds the sequence to the test log for the record.
+// stage the run reported was a scripted one (no surprise or unknown variant),
+// and both scripted stages were observed. Requests reporting no stage are the
+// turns that issue the stage-selecting code call, so they are expected — a
+// surprise non-goal call would still fail, because its code call would find no
+// goal_control in its catalog and report an error marker instead. That the two
+// enqueued stages were consumed is enforced by the fake's cleanup; this adds the
+// sequence to the test log for the record.
 func assertGoalFakeRequests(t *testing.T, fake *fakeAnthropic) {
 	t.Helper()
 	reqs := fake.requests()
 	seen := map[string]int{}
 	for i, r := range reqs {
-		switch r.GoalControl {
+		switch r.GoalStage {
+		case "":
 		case "decompose", "submit":
-			seen[r.GoalControl]++
+			seen[r.GoalStage]++
 		default:
-			t.Errorf("model request %d had goal_control=%q; want a scripted decompose/submit stage", i, r.GoalControl)
+			t.Errorf("model request %d reported stage %q; want a scripted decompose/submit stage", i, r.GoalStage)
 		}
 	}
 	if seen["decompose"] == 0 || seen["submit"] == 0 {
-		t.Errorf("fake saw decompose=%d submit=%d requests, want at least one of each", seen["decompose"], seen["submit"])
+		t.Errorf("fake saw decompose=%d submit=%d stage reports, want at least one of each", seen["decompose"], seen["submit"])
 	}
 	t.Logf("goal journey model requests (%d): %s", len(reqs), summarizeGoalRequests(reqs))
 }
 
-// summarizeGoalRequests renders the goal_control stage of each request in
-// arrival order for diagnostics, e.g. "decompose, decompose, submit".
+// summarizeGoalRequests renders the goal_control stage each request reported, in
+// arrival order, for diagnostics — e.g. "<call>, decompose, <call>, submit".
 func summarizeGoalRequests(reqs []fakeRequest) string {
 	stages := make([]string, len(reqs))
 	for i, r := range reqs {
-		stages[i] = r.GoalControl
+		stages[i] = r.GoalStage
 		if stages[i] == "" {
-			stages[i] = "<none>"
+			stages[i] = "<call>"
 		}
 	}
 	return strings.Join(stages, ", ")

--- a/test/system/goal_test.go
+++ b/test/system/goal_test.go
@@ -331,6 +331,16 @@ func (h *harness) assertGoalSessionsLive(t *testing.T, ctx context.Context, root
 // goal_control in its catalog and report an error marker instead. That the two
 // enqueued stages were consumed is enforced by the fake's cleanup; this adds the
 // sequence to the test log for the record.
+//
+// It also pins the tool surface every Goal turn was actually offered, which the
+// rest of the journey cannot see. The runner dispatches an outer call on the
+// name alone, so the fake can invoke `code` whether or not the server advertised
+// it: without this check, a regression that dropped `code` from the
+// provider-facing definitions while leaving the catalog intact would keep this
+// journey green and leave a real model with no way in. Asserting `goal_control`
+// is absent pins the other half — it is a cold tool, reached through the
+// catalog, and its reappearance here would mean the journey had quietly stopped
+// covering the Code Mode path.
 func assertGoalFakeRequests(t *testing.T, fake *fakeAnthropic) {
 	t.Helper()
 	reqs := fake.requests()
@@ -342,6 +352,12 @@ func assertGoalFakeRequests(t *testing.T, fake *fakeAnthropic) {
 			seen[r.GoalStage]++
 		default:
 			t.Errorf("model request %d reported stage %q; want a scripted decompose/submit stage", i, r.GoalStage)
+		}
+		if !containsString(r.ToolNames, "code") {
+			t.Errorf("model request %d offered tools %v; want code among them, or no model could reach goal_control", i, r.ToolNames)
+		}
+		if containsString(r.ToolNames, "goal_control") {
+			t.Errorf("model request %d advertised goal_control natively; it must stay cold and be reached through the code catalog", i)
 		}
 	}
 	if seen["decompose"] == 0 || seen["submit"] == 0 {

--- a/test/system/image_history_test.go
+++ b/test/system/image_history_test.go
@@ -230,27 +230,39 @@ func (h *harness) setVisionModel(t *testing.T, ctx context.Context, model string
 	}
 }
 
+// assertCanonicalImageStored proves the durable shape of one stored image: the
+// baseline lives on the media object (never copied onto the part), the parent
+// message's text projection carries that same baseline, and no provider Base64
+// reached the canonical row.
 func (h *harness) assertCanonicalImageStored(t *testing.T, ctx context.Context, sessionID, role, encoded string, size int64) (baseline, mediaID string) {
 	t.Helper()
 	var (
 		parentContent string
+		partText      *string // image parts carry no text of their own; NULL is the contract
 		mimeType      string
 		storedSize    int64
 	)
+	// The baseline is a column of ctx_media, keyed by (owner, sha256), not of the
+	// part that happens to reference it (migration 90000000000030): one image
+	// forwarded into two messages is described once. Reading it from the part
+	// would only ever see NULL.
 	err := h.db.QueryRow(ctx, `
-		SELECT m.content, p.text_content, p.media_id::text, media.mime_type, media.size_bytes
+		SELECT m.content, p.text_content, media.baseline, p.media_id::text, media.mime_type, media.size_bytes
 		  FROM ctx_conversation c
 		  JOIN ctx_message m ON m.conversation_id = c.id
 		  JOIN ctx_message_part p ON p.message_id = m.id AND p.part_type = 'image'
 		  JOIN ctx_media media ON media.id = p.media_id
 		 WHERE c.session_id = $1 AND m.role = $2
 		 ORDER BY m.seq, p.ordinal
-		 LIMIT 1`, sessionID, role).Scan(&parentContent, &baseline, &mediaID, &mimeType, &storedSize)
+		 LIMIT 1`, sessionID, role).Scan(&parentContent, &partText, &baseline, &mediaID, &mimeType, &storedSize)
 	if err != nil {
 		t.Fatalf("query canonical image history: %v\n%s", err, h.proc.logTail(40))
 	}
+	if partText != nil {
+		t.Fatalf("canonical image part froze a text copy %q; the baseline belongs to ctx_media alone", *partText)
+	}
 	if baseline == "" {
-		t.Fatal("canonical image part has empty baseline")
+		t.Fatal("canonical image media has empty baseline")
 	}
 	projectedParent := parentContent
 	if role == "tool" {

--- a/test/system/image_history_test.go
+++ b/test/system/image_history_test.go
@@ -48,7 +48,7 @@ func (h *harness) testImageHistory(t *testing.T) {
 	agentID := h.createAgent(t, ctx, providerID+"/"+modelID)
 	sessionID := h.createSession(t, ctx, agentID)
 
-	original := systemPNG(t)
+	original := systemPNG(t, 90)
 	encoded := base64.StdEncoding.EncodeToString(original)
 	firstEvents, gotFirstReply := h.streamChatParts(t, ctx, agentID, sessionID, []map[string]any{
 		{"type": "image", "image": encoded, "mimeType": "image/png"},
@@ -112,7 +112,10 @@ func (h *harness) testViewImageToolHistory(t *testing.T) {
 	agentID := h.createAgent(t, ctx, providerID+"/"+modelID)
 	sessionID := h.createSession(t, ctx, agentID)
 
-	original := systemPNG(t)
+	// Distinct pixels from image_history's: same owner, so identical bytes would
+	// resolve to that journey's already-described media object and this journey
+	// would never reach the VLM. See systemPNG.
+	original := systemPNG(t, 200)
 	encoded := base64.StdEncoding.EncodeToString(original)
 	imagePath := h.uploadWorkspaceImage(t, ctx, agentID, sessionID, original)
 	toolArgs, err := json.Marshal(map[string]string{"path": imagePath})
@@ -351,12 +354,22 @@ func (h *harness) assertHistoryLoadsOriginal(t *testing.T, ctx context.Context, 
 	}
 }
 
-func systemPNG(t *testing.T) []byte {
+// systemPNG builds an 8x8 synthetic PNG whose blue channel is the caller's, so
+// two journeys can hold provably different bytes.
+//
+// That parameter is load-bearing, not decoration. Session media is deduplicated
+// by (owner, sha256) and the baseline is a property of that media row (#1183),
+// and every journey here runs as the same bootstrap user. Two journeys sharing
+// one byte stream would therefore share one media object: the second would adopt
+// the first's stored description, skip the VLM entirely, and assert nothing at
+// all about the render path it exists to cover. A journey that measures baseline
+// rendering owns its own pixels.
+func systemPNG(t *testing.T, blue uint8) []byte {
 	t.Helper()
 	img := image.NewRGBA(image.Rect(0, 0, 8, 8))
 	for y := range 8 {
 		for x := range 8 {
-			img.SetRGBA(x, y, color.RGBA{R: uint8(x * 20), G: uint8(y * 20), B: 90, A: 255})
+			img.SetRGBA(x, y, color.RGBA{R: uint8(x * 20), G: uint8(y * 20), B: blue, A: 255})
 		}
 	}
 	var out bytes.Buffer

--- a/web/content/docs/development/rules/system-test.md
+++ b/web/content/docs/development/rules/system-test.md
@@ -134,17 +134,20 @@ that made fewer model calls than the journey assumed.
 ### Reaching goal_control under Code Mode
 
 Code Mode is the only tool path, so `goal_control` is a **cold** tool: it is
-absent from the request's tool list, and a decomposition turn is byte-identical
-to an execution turn. The discriminator did not disappear, it moved — the
-per-attempt `goal_control` schema now reaches the model through the code
-catalog — so the fake fetches it from there in two steps:
+absent from the request's tool list, and nothing in the provider-facing tool
+surface tells a decomposition turn from an execution one. The prompts and
+histories do differ, but those are prose the fake must never branch on. The
+discriminator did not disappear, it moved — the per-attempt `goal_control`
+schema now reaches the model through the code catalog — so the fake fetches it
+from there in two steps:
 
 1. **Probe.** A fresh Goal turn is answered with a `code` call that returns
    `tools.describe("goal_control").inputSchema.properties.action.enum`. Nothing
    terminal runs, so the attempt is guaranteed to ask again.
 2. **Stage.** The turn answering the probe carries that enum, so the fake picks
    the non-`fail` action and serves that stage's `tools.invoke("goal_control", …)`
-   call, recording the stage as requested.
+   call, recording the stage as requested **at that moment** — see the gotcha
+   below for why it cannot wait.
 
 The fake reads only markers it planted itself in its own scripts' return values,
 never prompt prose, so the matching field is still the action enum and ordinary
@@ -154,12 +157,20 @@ prompt edits still cannot fail the suite.
 
 A Goal attempt's agent tool loop may fire a **racy tool-result follow-up call**
 after the terminal `goal_control` invocation, so the number of `/v1/messages`
-calls per attempt is nondeterministic — an execution attempt takes that extra
-turn and a decomposition attempt does not. This is exactly why the goal mode keys
-on the action enum instead of arrival order: each stage is served once, and a
-follow-up turn gets a benign `end_turn` text so the loop terminates without
-consuming another stage's script. Assert "all scripts consumed and no unscripted
-request," never an exact call count.
+calls per attempt is nondeterministic. It is a race, not a property of the
+purpose: any attempt may or may not take that turn, and observed runs include
+both (in the measured `goal_lifecycle` run neither attempt took one, giving
+`<call>, decompose, <call>, submit`).
+
+Two consequences. First, this is why the goal mode keys on the action enum
+instead of arrival order: each stage is served once, and a follow-up turn gets a
+benign `end_turn` text so the loop terminates without consuming another stage's
+script. Second, the fake must record a stage **when it serves that stage's
+script**, never when the script's marker comes back — the attempt ends on that
+call, so the marker may never arrive at all.
+
+Assert "all scripts consumed and no unscripted request," never an exact call
+count.
 
 ## Diagnostics
 

--- a/web/content/docs/development/rules/system-test.md
+++ b/web/content/docs/development/rules/system-test.md
@@ -124,23 +124,42 @@ edits can never turn into a system-test failure. It has two scripting modes:
 - **FIFO turns** (`enqueueText`) — an ordered queue replayed in arrival order;
   used by `chat_sse`, `image_history`, and `view_image_tool_history`. An unscripted request fails the test.
 - **goal_control variant match** (`enqueueGoalControl`) — responses keyed by the
-  `goal_control` action the server advertises in the request's tool schema
-  (`decompose`, `submit`), matched on that stable field rather than arrival order;
-  used by `goal_lifecycle`.
+  `goal_control` action the server advertises to that attempt (`decompose`,
+  `submit`), matched on that stable field rather than arrival order; used by
+  `goal_lifecycle`.
 
 Cleanup fails the test if any scripted response went unconsumed, catching a system
 that made fewer model calls than the journey assumed.
 
+### Reaching goal_control under Code Mode
+
+Code Mode is the only tool path, so `goal_control` is a **cold** tool: it is
+absent from the request's tool list, and a decomposition turn is byte-identical
+to an execution turn. The discriminator did not disappear, it moved — the
+per-attempt `goal_control` schema now reaches the model through the code
+catalog — so the fake fetches it from there in two steps:
+
+1. **Probe.** A fresh Goal turn is answered with a `code` call that returns
+   `tools.describe("goal_control").inputSchema.properties.action.enum`. Nothing
+   terminal runs, so the attempt is guaranteed to ask again.
+2. **Stage.** The turn answering the probe carries that enum, so the fake picks
+   the non-`fail` action and serves that stage's `tools.invoke("goal_control", …)`
+   call, recording the stage as requested.
+
+The fake reads only markers it planted itself in its own scripts' return values,
+never prompt prose, so the matching field is still the action enum and ordinary
+prompt edits still cannot fail the suite.
+
 ### Goal trailing-turn gotcha
 
 A Goal attempt's agent tool loop may fire a **racy tool-result follow-up call**
-after the terminal `goal_control` tool_use, so the number of `/v1/messages` calls
-per attempt is nondeterministic (the measured `goal_lifecycle` sequence is
-`decompose, decompose, submit, submit`). This is exactly why the goal mode keys on
-the action enum instead of arrival order: each stage's tool_use is served once,
-and a same-stage follow-up turn gets a benign `end_turn` text so the loop
-terminates without consuming another stage's script. Assert "all scripts consumed
-and no unscripted request," never an exact call count.
+after the terminal `goal_control` invocation, so the number of `/v1/messages`
+calls per attempt is nondeterministic — an execution attempt takes that extra
+turn and a decomposition attempt does not. This is exactly why the goal mode keys
+on the action enum instead of arrival order: each stage is served once, and a
+follow-up turn gets a benign `end_turn` text so the loop terminates without
+consuming another stage's script. Assert "all scripts consumed and no unscripted
+request," never an exact call count.
 
 ## Diagnostics
 

--- a/web/content/docs/development/rules/system-test.zh.md
+++ b/web/content/docs/development/rules/system-test.zh.md
@@ -100,26 +100,42 @@ journey 依赖另一个 journey 的业务数据 —— 唯一的复用是共享�
 是因为测试创建的 provider 的 `base_url` 就是 fake 的回环地址。因此 fake 记录的每一个请求，
 就是系统发出的每一个模型请求。
 
-fake **绝不根据 prompt 文案分支** —— 只有稳定的请求字段（model、tool 名、`goal_control` 的
-action 枚举）才选择响应，所以普通的 prompt 改动永远不会变成系统测试失败。它有两种脚本模式：
+fake **绝不根据 prompt 文案分支** —— 只有稳定的结构化字段（model、tool 名、`goal_control` 的
+action 枚举，以及 fake 自己植入、又在 tool result 里回到它手上的 marker）才选择响应，所以普通
+的 prompt 改动永远不会变成系统测试失败。它有两种脚本模式：
 
 - **FIFO 轮次**（`enqueueText`）—— 一个按到达顺序回放的有序队列；由 `chat_sse`、
   `image_history` 和 `view_image_tool_history` 使用。未脚本化的请求会让测试失败。
-- **goal_control 变体匹配**（`enqueueGoalControl`）—— 响应按服务器在请求 tool schema 中广告
-  的 `goal_control` action（`decompose`、`submit`）作键，按该稳定字段而非到达顺序匹配；由
+- **goal_control 变体匹配**（`enqueueGoalControl`）—— 响应按服务器向该 attempt 广告的
+  `goal_control` action（`decompose`、`submit`）作键，按该稳定字段而非到达顺序匹配；由
   `goal_lifecycle` 使用。
 
 清理阶段会在任何脚本化响应未被消费时让测试失败，从而捕获"系统实际发起的模型调用比 journey
 假设的更少"这种情况。
 
+### Code Mode 下如何够到 goal_control
+
+Code Mode 是唯一的 tool 路径，因此 `goal_control` 是**冷** tool：它不出现在请求的 tool 列表
+里，一次 decomposition 轮次与一次 execution 轮次在字节上完全相同。判别维度并没有消失，只是
+搬了家 —— 每个 attempt 的 `goal_control` schema 现在经 code catalog 抵达模型 —— 所以 fake
+分两步从那里取：
+
+1. **探针。** 一个全新的 Goal 轮次会得到一个 `code` 调用，返回
+   `tools.describe("goal_control").inputSchema.properties.action.enum`。这一步没有任何终止性
+   动作，因此该 attempt 必然会再问一次。
+2. **Stage。** 回答探针的那次请求带着这个枚举，fake 取其中非 `fail` 的 action，发出该 stage
+   的 `tools.invoke("goal_control", …)` 调用，并把该 stage 记为已请求。
+
+fake 只读自己在脚本返回值里植入的 marker，绝不读 prompt 文案，所以匹配字段依然是 action 枚举，
+普通的 prompt 改动依然不会让套件变红。
+
 ### Goal trailing-turn 陷阱
 
-一个 Goal attempt 的 agent tool loop 可能在终止性的 `goal_control` tool_use 之后**再打一次
-竞态的 tool-result 后续调用**，因此每个 attempt 的 `/v1/messages` 调用次数是不确定的（实测
-`goal_lifecycle` 序列为 `decompose, decompose, submit, submit`）。这正是 goal 模式按 action
-枚举而非到达顺序作键的原因：每个 stage 的 tool_use 只发一次，而同一 stage 的后续轮次会得到一个
-无害的 `end_turn` 文本，使循环终止而不消费另一个 stage 的脚本。断言应是"所有脚本已消费且无未
-脚本请求"，绝不断言精确调用次数。
+一个 Goal attempt 的 agent tool loop 可能在终止性的 `goal_control` 调用之后**再打一次竞态的
+tool-result 后续调用**，因此每个 attempt 的 `/v1/messages` 调用次数是不确定的 —— execution
+attempt 会多这一轮，decomposition attempt 不会。这正是 goal 模式按 action 枚举而非到达顺序作键
+的原因：每个 stage 只发一次，而后续轮次会得到一个无害的 `end_turn` 文本，使循环终止而不消费另一个
+stage 的脚本。断言应是"所有脚本已消费且无未脚本请求"，绝不断言精确调用次数。
 
 ## 诊断
 

--- a/web/content/docs/development/rules/system-test.zh.md
+++ b/web/content/docs/development/rules/system-test.zh.md
@@ -116,15 +116,17 @@ action 枚举，以及 fake 自己植入、又在 tool result 里回到它手上
 ### Code Mode 下如何够到 goal_control
 
 Code Mode 是唯一的 tool 路径，因此 `goal_control` 是**冷** tool：它不出现在请求的 tool 列表
-里，一次 decomposition 轮次与一次 execution 轮次在字节上完全相同。判别维度并没有消失，只是
-搬了家 —— 每个 attempt 的 `goal_control` schema 现在经 code catalog 抵达模型 —— 所以 fake
-分两步从那里取：
+里，面向 provider 的 tool surface 里没有任何东西能把 decomposition 轮次和 execution 轮次区分
+开。prompt 与 history 确实不同，但那是 fake 绝不能分支的文案。判别维度并没有消失，只是搬了家
+—— 每个 attempt 的 `goal_control` schema 现在经 code catalog 抵达模型 —— 所以 fake 分两步
+从那里取：
 
 1. **探针。** 一个全新的 Goal 轮次会得到一个 `code` 调用，返回
    `tools.describe("goal_control").inputSchema.properties.action.enum`。这一步没有任何终止性
    动作，因此该 attempt 必然会再问一次。
 2. **Stage。** 回答探针的那次请求带着这个枚举，fake 取其中非 `fail` 的 action，发出该 stage
-   的 `tools.invoke("goal_control", …)` 调用，并把该 stage 记为已请求。
+   的 `tools.invoke("goal_control", …)` 调用，并**在此刻**把该 stage 记为已请求 —— 为什么不能
+   等，见下面的陷阱。
 
 fake 只读自己在脚本返回值里植入的 marker，绝不读 prompt 文案，所以匹配字段依然是 action 枚举，
 普通的 prompt 改动依然不会让套件变红。
@@ -132,10 +134,16 @@ fake 只读自己在脚本返回值里植入的 marker，绝不读 prompt 文案
 ### Goal trailing-turn 陷阱
 
 一个 Goal attempt 的 agent tool loop 可能在终止性的 `goal_control` 调用之后**再打一次竞态的
-tool-result 后续调用**，因此每个 attempt 的 `/v1/messages` 调用次数是不确定的 —— execution
-attempt 会多这一轮，decomposition attempt 不会。这正是 goal 模式按 action 枚举而非到达顺序作键
-的原因：每个 stage 只发一次，而后续轮次会得到一个无害的 `end_turn` 文本，使循环终止而不消费另一个
-stage 的脚本。断言应是"所有脚本已消费且无未脚本请求"，绝不断言精确调用次数。
+tool-result 后续调用**，因此每个 attempt 的 `/v1/messages` 调用次数是不确定的。这是竞态，不是
+purpose 的属性：任何 attempt 都可能有、也可能没有这一轮，实测两种都出现过（实测那次
+`goal_lifecycle` 里两个 attempt 都没有，序列为 `<call>, decompose, <call>, submit`）。
+
+由此有两个后果。其一，这正是 goal 模式按 action 枚举而非到达顺序作键的原因：每个 stage 只发
+一次，而后续轮次会得到一个无害的 `end_turn` 文本，使循环终止而不消费另一个 stage 的脚本。
+其二，fake 必须在**发出某个 stage 的脚本时**就把它记为已请求，绝不能等脚本的 marker 回来 ——
+attempt 就终止在那次调用上，marker 可能根本不会到达。
+
+断言应是"所有脚本已消费且无未脚本请求"，绝不断言精确调用次数。
 
 ## 诊断
 


### PR DESCRIPTION
## What

Repairs the three `mise run system-test` journeys that were red on `main` at 4bc5a9916 — `image_history`, `view_image_tool_history`, and `goal_lifecycle` — one commit per journey. All three were stale assertions, not product defects; the fixes preserve each assertion's intent rather than relaxing it, and two of them strengthen it. No production code changes.

## Why

The suite has been failing since #1183 merged, and nothing caught it: CI does not run the system suite, so three PRs merged green over a broken gate.

`goal_lifecycle` is the only end-to-end coverage of the `goal_control` attempt protocol, and it has been dead since #1182 — it also happens to be the coverage that #1184's `goal_control` protocol exception points at. `image_history` / `view_image_tool_history` are the only end-to-end coverage of the canonical session-media path.

Reproduced on a clean checkout of `origin/main` before any change: exactly these three, with the failure text quoted below.

## How

**`image_history` — read the baseline from `ctx_media` (introduced by #1183).**
The journey scanned `ctx_message_part.text_content` as the stored baseline and died in the scan itself:

```
image_history_test.go:62: query canonical image history: can't scan into
dest[1] (col: text_content): cannot scan NULL into *string
```

#1183 moved the baseline onto `ctx_media` (migration `90000000000030`, keyed by owner+sha256 so one image forwarded into two messages is described once) and stopped writing a frozen copy onto the part — `canonicalParts` now emits an image part with no text at all. The assertion keeps its intent, canonical history stores that exact scripted VLM baseline and no provider Base64, by reading `ctx_media.baseline`, and gains the invariant that should now hold: the part carries no text copy of its own.

**`view_image_tool_history` — give each image journey its own pixels (introduced by #1183).**
Both journeys built the identical 8x8 PNG and both run as the shared bootstrap user, so the second journey's upload resolved to the *first* journey's media object: `mediaStore.Persist` returned its stored baseline, `enricher.persistOne` set `task.stored`, and `renderOne` skipped the VLM entirely. With no baseline request, the FIFO script slid one turn:

```
image_history_test.go:133: tool-loop assistant text =
"## Text\nview_image tool pixels\n\n## Scene\n..." ,
want "view_image tool image received, run 87ce8356"
```

Describe-once-per-media is exactly what #1183 set out to do. But it means a journey asserting anything about the render path must own bytes no other journey shares, or it silently measures nothing. `systemPNG` now takes the blue channel, and the comment says why the parameter is load-bearing.

**`goal_lifecycle` — reach `goal_control` through the code catalog (introduced by #1182).**
The journey hung for its full 120s budget, then failed with eighteen copies of:

```
fake anthropic: unscripted goal request (goal_control="",
model="claude-sonnet-4-6"); no stage was enqueued for it
```

The fake picked a Goal stage by reading the `goal_control` action enum out of the request's tool schema. #1182 made Code Mode the only tool path, so `goal_control` is a cold tool: absent from the provider-facing tool list (`[bash memory_read memory_search skill_load view_image code]`), and nothing in that surface tells a decomposition turn from an execution one. (The prompts and histories do differ — but those are prose the fake must never branch on.) Every attempt failed out, the composite blocked on `env_unavailable`, and the journey timed out.

`goal_control` itself is fine — it is still registered as a per-run tool on every attempt and still reachable. The fixed journey drives both stages through `tools.invoke("goal_control", …)` and the server records `{"ok":true,"recorded":"decompose"}` / `{"ok":true,"recorded":"submit"}`. What broke is only the fake's matching dimension.

The discriminator did not disappear, it moved: the per-attempt `goal_control` schema now reaches the model through the code catalog. So the fake fetches it from there in two steps and keeps matching on exactly the field it always did:

1. a fresh Goal turn gets a probe `code` call returning `tools.describe("goal_control").inputSchema.properties.action.enum`. Nothing terminal runs, so the attempt is guaranteed to ask again;
2. the turn answering the probe carries that enum, so the fake serves that stage's `goal_control` invocation and records the stage as requested.

The fake still never branches on prompt prose: it reads only markers it planted in its own scripts' return values.

Recording a stage when its script is **served**, not when its marker comes back, is deliberate. The attempt ends on that call, and whether the agent loop takes one more racy tool-result turn is not a property of the attempt's purpose: an earlier iteration of this branch saw an execution attempt take one, and the measured passing run shows neither attempt taking one. That iteration waited for the follow-up and consequently saw `submit` and never `decompose`.

`assertGoalFakeRequests` also pins the tool surface each Goal turn was offered: `code` present, `goal_control` absent. The runner dispatches an outer call on the name alone, so the fake can invoke `code` whether or not the server advertised it — without this check, a regression that dropped `code` from the provider-facing definitions while leaving the catalog intact would keep the journey green and still leave a real model with no way in. With it, the chain is closed end to end: the model can see the entry point, the catalog can see the cold tool, the invocation really executes, and the goal reaches accepted.

**Recommendation, not implemented here: run the system suite on a nightly schedule, not on every PR.**

The evidence for doing something is direct — this PR exists because three changes merged over a gate nobody ran. The evidence against putting it on PRs is the cost and the blast radius: the suite is ~85s of test after a full `build` (Go binary + web assets + generators, several minutes on a cold runner), it needs the embedded PostgreSQL runtime download plus bubblewrap with `kernel.apparmor_restrict_unprivileged_userns=0`, and it boots one shared server whose journeys run in order — so a single flake fails the whole suite, on every PR, including PRs that touch nothing it covers.

Concretely, I would:

- add a `schedule:` (nightly) + `workflow_dispatch` job that runs `mise run system-test` on `main`, reusing the `release.yml` `system` job verbatim — same `ubuntu-24.04` pin, same bubblewrap setup, same `dist/logs/system-test/` artifact upload — and opens or updates an issue on failure so a red night is visible without anyone watching Actions;
- keep it *off* the PR path for now, and revisit if nightly turns out to be stable and fast enough that the cost is acceptable.

A cheaper middle option, if nightly is judged too loose: run it on PRs only when the diff touches `test/system/`, `internal/goal/`, `internal/sessionmedia/`, `pkg/agent/`, or `cmd/stellad/` via `paths:`. I did not recommend it as the default because it would not have caught #1183 any earlier than nightly would, and path filters rot silently.

## Test

Both gates re-run at the review-fix commit (`0c6637e`):

- `bash -c 'mise run format && mise run build && mise run test; echo exit=$?'` → **exit=0**
- `bash -c 'mise run system-test; echo exit=$?'` → **exit=0** (`ok github.com/CherryHQ/stella/test/system 82.103s`). The same command on `origin/main` before this branch: **exit=1**, `FAIL ... 197.439s`, with the three failures quoted above.
- `goal_lifecycle` alone: passes with the request log `<call>, decompose, <call>, submit` and both scripted stages consumed. It was previously burning its full 120s budget.
- The new tool-surface assertion is not vacuous: the `code`-present half passing proves `ToolNames` is populated, which is what would otherwise make the `goal_control`-absent half trivially true.

Host: macOS arm64 (a supported platform for the embedded PostgreSQL runtime).

## Refs

Closes #1185
Refs STELLA-45. Introduced by #1182 (goal) and #1183 (both image journeys). Related: #1184, whose `goal_control` protocol exception cites `goal_lifecycle` as its coverage.

## Checklist

- [x] The PR links a GitHub issue, or states why the fix is small enough not to need one. — #1185.
- [x] I added or updated focused tests for changed non-trivial behavior, or explained why none are needed. — this PR *is* the test change; no production behavior changed.
- [x] I updated relevant English and Chinese documentation, or no documentation change is needed. — `system-test.md` and `system-test.zh.md` gained a "Reaching goal_control under Code Mode" section and a corrected trailing-turn note.
- [x] I ran `mise run format && mise run build && mise run test`. — exit=0.
- [x] If this changes agent behavior (tools, prompts, the runner loop): eval evidence. — **Not applicable**: no production code is touched; the diff is `test/system/` plus two rule docs.
- [x] If the change touches a surface no eval task exercises (pixel understanding, document extraction, CRLF fidelity, non-UTF-8, binary handling): named the tests covering it instead. — pixel handling is exercised here by `image_history` and `view_image_tool_history` themselves, which is the point of the repair; no eval task covers images.
- [x] Any earlier measurement this PR invalidates is marked superseded with its reason, not deleted. — none; no measurement is invalidated.

## Feishu Task

- [修复 main 上三条红灯 system-test 旅程](https://mcnnox2fhjfq.feishu.cn/record/RvCfrvPrzexccWc8qLec5rEBnyc) (#1185)
