### PR TITLE
📡 observability: repair agent-loop telemetry pipeline

### DIFF
--- a/cmd/stellad/commands.go
+++ b/cmd/stellad/commands.go
@@ -45,6 +45,7 @@ import (
 	"github.com/CherryHQ/stella/internal/memory"
 	"github.com/CherryHQ/stella/internal/notify"
 	"github.com/CherryHQ/stella/internal/observability"
+	"github.com/CherryHQ/stella/internal/observability/metrichook"
 	"github.com/CherryHQ/stella/internal/observability/tracehook"
 	"github.com/CherryHQ/stella/internal/pluginhost"
 	"github.com/CherryHQ/stella/internal/recally"
@@ -146,6 +147,7 @@ type setupResult struct {
 	cliUserID                int64
 	oauthRegistry            *oauth.ProviderRegistry
 	backgroundTasks          *sync.WaitGroup
+	metricHook               *metrichook.Hook
 }
 
 // manifestReconciler schedules the background install of manifest plugin
@@ -436,8 +438,10 @@ func setup(parent context.Context, cfg config.ServerConfig, baseURL string, opts
 	traceHook := tracehook.New(observability.LoadConfig().Enabled, cfg.Observability.RecordToolIO,
 		tracehook.WithToolMeta(toolMetaRegistry))
 	traceHook.Start(parent)
+	metricHook := metrichook.New(usageHook, traceHook.ActiveSessions)
+	usageHook.SetDropObserver(metricHook.RecordQueueDrop)
 	usageHook.Start()
-	coreHooks := []hooks.HookPlugin{traceHook, usageHook}
+	coreHooks := []hooks.HookPlugin{traceHook, usageHook, metricHook}
 
 	toolLifecycle := buildToolLifecycle(phost)
 	promptSectionsBuilder := func(ctx context.Context, build pkgplugins.SystemPromptContext) ([]pkgplugins.SystemPromptSection, error) {
@@ -703,6 +707,7 @@ func setup(parent context.Context, cfg config.ServerConfig, baseURL string, opts
 		cliUserID:                0,
 		oauthRegistry:            ps.oauthRegistry,
 		backgroundTasks:          backgroundTasks,
+		metricHook:               metricHook,
 	}
 	// Ownership of the embedded server moves to result; clear the local so the
 	// cleanup defer above becomes a no-op on this success path.

--- a/cmd/stellad/commands.go
+++ b/cmd/stellad/commands.go
@@ -438,7 +438,10 @@ func setup(parent context.Context, cfg config.ServerConfig, baseURL string, opts
 	traceHook := tracehook.New(observability.LoadConfig().Enabled, cfg.Observability.RecordToolIO,
 		tracehook.WithToolMeta(toolMetaRegistry))
 	traceHook.Start(parent)
-	metricHook := metrichook.New(usageHook, traceHook.ActiveSessions)
+	metricHook := metrichook.New(usageHook, traceHook.ActiveSessions, func(name string) bool {
+		_, ok := toolMetaRegistry.Lookup(name)
+		return ok
+	})
 	usageHook.SetDropObserver(metricHook.RecordQueueDrop)
 	usageHook.Start()
 	coreHooks := []hooks.HookPlugin{traceHook, usageHook, metricHook}

--- a/cmd/stellad/gateway.go
+++ b/cmd/stellad/gateway.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"filippo.io/age"
+	"go.opentelemetry.io/otel"
 
 	ucli "github.com/urfave/cli/v2"
 
@@ -189,20 +190,15 @@ func serverAction(c *ucli.Context) error {
 
 	startDiagnostics(ctx, cfg.Diagnostics.PprofAddr)
 
-	s, err := setup(ctx, cfg, baseURL)
+	// Register provider shutdown before setup cleanup so defer LIFO closes pools
+	// and trace hooks first, then flushes the provider with all final spans/logs.
+	// Init is deliberately before setup: setup captures component loggers, and
+	// those loggers must already point at the tee handler to reach OTLP.
+	obs, err := observability.Init(ctx)
 	if err != nil {
 		cancel()
-		return err
+		return fmt.Errorf("init observability: %w", err)
 	}
-
-	// Both cleanup defers are registered before observability.Init so a failed
-	// Init still drains setup's resources (pools, background tasks). obs is a
-	// nil-safe Provider until assigned, so its Shutdown is a no-op if Init never
-	// ran. The shutdown defer is registered FIRST so it runs LAST (LIFO): only
-	// after poolManager.Close() → tracehook.Close() → endSession() has ended
-	// every in-flight session span do we flush and stop the provider, otherwise
-	// those end-of-session spans land on a stopped provider and get dropped.
-	var obs *observability.Provider
 	defer func() {
 		shutCtx, shutCancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer shutCancel()
@@ -210,6 +206,19 @@ func serverAction(c *ucli.Context) error {
 			slog.Warn("otel shutdown failed", "error", err)
 		}
 	}()
+
+	s, err := setup(ctx, cfg, baseURL)
+	if err != nil {
+		cancel()
+		return err
+	}
+	if s.metricHook != nil {
+		if err := s.metricHook.Bind(otel.Meter("stella")); err != nil {
+			cancel()
+			return fmt.Errorf("bind observability metrics: %w", err)
+		}
+	}
+
 	defer func() {
 		cancel()
 		s.waitBackgroundTasks()
@@ -223,12 +232,6 @@ func serverAction(c *ucli.Context) error {
 			_ = s.embedded.Stop()
 		}
 	}()
-
-	// Initialize global OTel tracing before any component creates spans.
-	obs, err = observability.Init(ctx)
-	if err != nil {
-		return fmt.Errorf("init observability: %w", err)
-	}
 
 	listFn := func() []pkgchannel.ModelOption {
 		return collectModelsFromStore(s.ctx, s.store)

--- a/cmd/stellad/gateway.go
+++ b/cmd/stellad/gateway.go
@@ -203,7 +203,8 @@ func serverAction(c *ucli.Context) error {
 		shutCtx, shutCancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer shutCancel()
 		if err := obs.Shutdown(shutCtx); err != nil {
-			slog.Warn("otel shutdown failed", "error", err)
+			slog.Warn("otel shutdown failed", "error.type", fmt.Sprintf("%T", err), "error.class", "provider_shutdown_failed")
+			observability.ConsoleOnlyLogger().Warn("otel shutdown detail", "error", err)
 		}
 	}()
 
@@ -212,7 +213,7 @@ func serverAction(c *ucli.Context) error {
 		cancel()
 		return err
 	}
-	if s.metricHook != nil {
+	if s.metricHook != nil && obs.MetricsEnabled() {
 		if err := s.metricHook.Bind(otel.Meter("stella")); err != nil {
 			cancel()
 			return fmt.Errorf("bind observability metrics: %w", err)
@@ -735,7 +736,7 @@ func runServer(ctx context.Context, s *setupResult, loginConfig oidc.LoginConfig
 		// logged, not fatal — the hard stop below still bounds the process.
 		waitAccepted: func(ctx context.Context) {
 			if err := s.poolManager.WaitInFlight(ctx); err != nil {
-				slog.Warn("graceful drain: accepted agent turns still in flight when the budget expired", "error", err)
+				slog.Warn("graceful drain: accepted agent turns still in flight when the budget expired", "error.type", fmt.Sprintf("%T", err), "error.class", "drain_wait_failed")
 			}
 		},
 		cancelWork: workCancel,

--- a/cmd/stellad/gateway_order_test.go
+++ b/cmd/stellad/gateway_order_test.go
@@ -63,6 +63,40 @@ func runServerCallLines(t *testing.T) map[string]int {
 	return lines
 }
 
+func TestObservabilityInitializesBeforeSetup(t *testing.T) {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "gateway.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parse gateway.go: %v", err)
+	}
+	var initLine, setupLine int
+	ast.Inspect(f, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if ident, ok := call.Fun.(*ast.Ident); ok && ident.Name == "setup" && setupLine == 0 {
+			setupLine = fset.Position(call.Pos()).Line
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		if sel.Sel.Name == "Init" {
+			if ident, ok := sel.X.(*ast.Ident); ok && ident.Name == "observability" && initLine == 0 {
+				initLine = fset.Position(call.Pos()).Line
+			}
+		}
+		return true
+	})
+	if initLine == 0 || setupLine == 0 {
+		t.Fatalf("observability.Init=%d setup=%d", initLine, setupLine)
+	}
+	if initLine >= setupLine {
+		t.Fatalf("observability.Init line %d must precede setup line %d", initLine, setupLine)
+	}
+}
+
 func TestRunServerStartsBackendsBeforeIngress(t *testing.T) {
 	lines := runServerCallLines(t)
 

--- a/internal/agent/runner_impl.go
+++ b/internal/agent/runner_impl.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/CherryHQ/stella/internal/agent/agentctx"
 	"github.com/CherryHQ/stella/internal/agent/agenterr"
 	delegatetool "github.com/CherryHQ/stella/internal/agent/delegate"
 	"github.com/CherryHQ/stella/internal/agent/prompt"
@@ -571,6 +572,10 @@ func (r *runner) Chat(ctx context.Context, history []ai.Message, message Message
 			SessionID: memory.SessionIDFromContext(ctx),
 			UserID:    authz.UserIDFromContext(ctx),
 			AgentID:   authz.AgentIDFromContext(ctx),
+			BindingID: func() string {
+				binding, _ := agentctx.ChatBindingFromContext(ctx)
+				return binding.Channel
+			}(),
 			Channel: func() string {
 				channel, _ := ChannelFromContext(ctx)
 				return channel

--- a/internal/agent/runtime/chat.go
+++ b/internal/agent/runtime/chat.go
@@ -81,12 +81,8 @@ func (rt *Runtime) chatWithRunner(ctx context.Context, out chan<- Event, info se
 	if info.ProjectID != "" {
 		ctx = memory.WithProjectID(ctx, info.ProjectID)
 	}
-	channelValue := co.channel
-	if channelValue == "" {
-		channelValue = info.Channel
-	}
-	if channelValue != "" {
-		ctx = withChannel(ctx, channelValue)
+	if co.channel != "" {
+		ctx = withChannel(ctx, co.channel)
 	}
 
 	memSess, err := info.MemoryScope()
@@ -125,17 +121,6 @@ func (rt *Runtime) chatWithRunner(ctx context.Context, out chan<- Event, info se
 	hs := hooks.NewHookSet(hookPlugins)
 	channelName := co.channel
 	bindingID := co.bindingID
-	if binding, ok := agentctx.ChatBindingFromContext(ctx); ok {
-		if channelName == "" {
-			channelName = binding.Channel
-		}
-		if bindingID == "" {
-			bindingID = binding.Channel
-		}
-	}
-	if channelName == "" {
-		channelName = info.Channel
-	}
 	hookMeta := hooks.HookMeta{
 		SessionID: info.ID,
 		UserID:    info.UserID,
@@ -144,7 +129,6 @@ func (rt *Runtime) chatWithRunner(ctx context.Context, out chan<- Event, info se
 		BindingID: bindingID,
 	}
 	ctx = hooks.WithTelemetryMeta(ctx, hookMeta.Channel, hookMeta.BindingID)
-	memSess.Channel = hookMeta.Channel
 	if !isGuest {
 		hs.RunPreAgentCall(ctx, &hooks.PreAgentCallContext{
 			HookMeta:   hookMeta,
@@ -374,11 +358,6 @@ func (rt *Runtime) getOrCreateReservedRunner(ctx context.Context, info session.I
 	}
 	if info.ProjectID != "" {
 		attrs = append(attrs, attribute.String("project_id", info.ProjectID))
-	}
-	if info.Channel != "" {
-		if _, ok := agentctx.ChannelFromContext(ctx); !ok {
-			attrs = append(attrs, attribute.String("stella.chat.channel", info.Channel))
-		}
 	}
 	if model != "" {
 		attrs = append(attrs, attribute.String("gen_ai.request.model", model))

--- a/internal/agent/runtime/chat.go
+++ b/internal/agent/runtime/chat.go
@@ -9,7 +9,6 @@ import (
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/CherryHQ/stella/internal/agent/agentctx"
@@ -18,6 +17,7 @@ import (
 	"github.com/CherryHQ/stella/internal/authz"
 	"github.com/CherryHQ/stella/internal/eventlog"
 	"github.com/CherryHQ/stella/internal/memory"
+	"github.com/CherryHQ/stella/internal/observability"
 	"github.com/CherryHQ/stella/internal/sessionmedia"
 	"github.com/CherryHQ/stella/pkg/ai"
 	"github.com/CherryHQ/stella/pkg/hooks"
@@ -81,8 +81,12 @@ func (rt *Runtime) chatWithRunner(ctx context.Context, out chan<- Event, info se
 	if info.ProjectID != "" {
 		ctx = memory.WithProjectID(ctx, info.ProjectID)
 	}
-	if info.Channel != "" {
-		ctx = withChannel(ctx, info.Channel)
+	channelValue := co.channel
+	if channelValue == "" {
+		channelValue = info.Channel
+	}
+	if channelValue != "" {
+		ctx = withChannel(ctx, channelValue)
 	}
 
 	memSess, err := info.MemoryScope()
@@ -119,17 +123,33 @@ func (rt *Runtime) chatWithRunner(ctx context.Context, out chan<- Event, info se
 		hookPlugins = rt.hookPlugins()
 	}
 	hs := hooks.NewHookSet(hookPlugins)
+	channelName := co.channel
+	bindingID := co.bindingID
+	if binding, ok := agentctx.ChatBindingFromContext(ctx); ok {
+		if channelName == "" {
+			channelName = binding.Channel
+		}
+		if bindingID == "" {
+			bindingID = binding.Channel
+		}
+	}
+	if channelName == "" {
+		channelName = info.Channel
+	}
 	hookMeta := hooks.HookMeta{
 		SessionID: info.ID,
 		UserID:    info.UserID,
 		AgentID:   info.AgentID,
-		Channel:   info.Channel,
+		Channel:   channelName,
+		BindingID: bindingID,
 	}
+	ctx = hooks.WithTelemetryMeta(ctx, hookMeta.Channel, hookMeta.BindingID)
+	memSess.Channel = hookMeta.Channel
 	if !isGuest {
 		hs.RunPreAgentCall(ctx, &hooks.PreAgentCallContext{
 			HookMeta:   hookMeta,
 			MessageLen: len(msgText),
-			Channel:    info.Channel,
+			Channel:    hookMeta.Channel,
 		})
 	}
 
@@ -339,7 +359,13 @@ func (rt *Runtime) chatWithRunner(ctx context.Context, out chan<- Event, info se
 func (rt *Runtime) getOrCreateReservedRunner(ctx context.Context, info session.Info, model string, extraTools []tools.Tool) (runnerSelection, error) {
 	attrs := []attribute.KeyValue{
 		attribute.String("gen_ai.conversation.id", info.ID),
-		attribute.String("agent_id", info.AgentID),
+		attribute.String("stella.agent_id", info.AgentID),
+	}
+	if channel, ok := agentctx.ChannelFromContext(ctx); ok {
+		attrs = append(attrs, attribute.String("stella.chat.channel", channel))
+	}
+	if binding, ok := agentctx.ChatBindingFromContext(ctx); ok {
+		attrs = append(attrs, attribute.String("stella.chat.binding_id", binding.Channel))
 	}
 	if info.GuestID == "" {
 		attrs = append(attrs, attribute.String("user_id", info.UserID))
@@ -350,7 +376,9 @@ func (rt *Runtime) getOrCreateReservedRunner(ctx context.Context, info session.I
 		attrs = append(attrs, attribute.String("project_id", info.ProjectID))
 	}
 	if info.Channel != "" {
-		attrs = append(attrs, attribute.String("stella.chat.channel", info.Channel))
+		if _, ok := agentctx.ChannelFromContext(ctx); !ok {
+			attrs = append(attrs, attribute.String("stella.chat.channel", info.Channel))
+		}
 	}
 	if model != "" {
 		attrs = append(attrs, attribute.String("gen_ai.request.model", model))
@@ -361,8 +389,7 @@ func (rt *Runtime) getOrCreateReservedRunner(ctx context.Context, info session.I
 
 	selection, err := rt.cache.getOrCreateReserved(spanCtx, info, model, "", extraTools...)
 	if err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, err.Error())
+		observability.RecordSpanError(span, err, "runner lookup failed")
 		return runnerSelection{}, err
 	}
 	if selection.model != "" {

--- a/internal/agent/runtime/chat_test.go
+++ b/internal/agent/runtime/chat_test.go
@@ -32,11 +32,12 @@ func (f sessionImagesFunc) Enrich(ctx context.Context, owner sessionmedia.Owner,
 var imageTestUserID = uuid.NewString()
 
 type recordingMemory struct {
-	mu            sync.Mutex
-	messages      []ai.Message
-	commits       []int64
-	appendError   error
-	assembleError error
+	mu             sync.Mutex
+	messages       []ai.Message
+	appendSessions []memory.Session
+	commits        []int64
+	appendError    error
+	assembleError  error
 }
 
 type snapshotRecordingMemory struct {
@@ -71,12 +72,13 @@ func (m *recordingMemory) Name() string { return "recording" }
 
 func (m *recordingMemory) Bootstrap(context.Context, memory.Session) error { return nil }
 
-func (m *recordingMemory) Append(_ context.Context, _ memory.Session, msgs ...ai.Message) error {
+func (m *recordingMemory) Append(_ context.Context, session memory.Session, msgs ...ai.Message) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.appendError != nil {
 		return m.appendError
 	}
+	m.appendSessions = append(m.appendSessions, session)
 	m.messages = append(m.messages, msgs...)
 	return nil
 }
@@ -125,6 +127,31 @@ func (r chatFakeRunner) Busy() bool              { return false }
 func (r chatFakeRunner) LastActivity() time.Time { return time.Now() }
 func (r chatFakeRunner) SystemPrompt() string    { return r.system }
 func (r chatFakeRunner) Close() error            { return nil }
+
+func TestTelemetryChannelDoesNotChangeDurableConversationChannel(t *testing.T) {
+	mem := &recordingMemory{}
+	rt, err := New(Config{
+		Memory: mem,
+		NewRunner: func(context.Context, RunnerParams) (Runner, error) {
+			return chatFakeRunner{events: []Event{{Text: "ok"}}}, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	info := session.Info{ID: "durable-channel", UserID: "user", AgentID: "agent", Kind: string(session.KindChat), Channel: "agent:user:telegram:private"}
+	for event := range rt.Chat(context.Background(), info, "hello", WithTelemetryChannel("telegram", "agent:user:telegram:private")) {
+		if event.Err != nil {
+			t.Fatal(event.Err)
+		}
+	}
+	if len(mem.appendSessions) == 0 {
+		t.Fatal("chat did not append a durable conversation message")
+	}
+	if got := mem.appendSessions[0].Channel; got != info.Channel {
+		t.Fatalf("durable channel = %q, want %q", got, info.Channel)
+	}
+}
 
 // TestRuntimeChatUnionsAncestorExcludedTools prevents a goal worker from
 // restoring a control-plane tool by delegating. The per-call exclusions model a

--- a/internal/agent/runtime/options.go
+++ b/internal/agent/runtime/options.go
@@ -19,6 +19,8 @@ type chatOptions struct {
 	inputActor     eventlog.MessageActor
 	inboxID        string
 	groupWake      memory.GroupWake
+	channel        string
+	bindingID      string
 }
 
 // WithInputActor attaches runtime-derived provenance to the input message.
@@ -53,6 +55,15 @@ func WithCurrentSpeaker(speaker memory.CurrentSpeaker) Option {
 func WithGroupWake(wake memory.GroupWake) Option {
 	return func(o *chatOptions) {
 		o.groupWake = wake
+	}
+}
+
+// WithTelemetryChannel records the low-cardinality transport and its separate
+// binding identifier in hook metadata without changing session routing.
+func WithTelemetryChannel(channel, bindingID string) Option {
+	return func(o *chatOptions) {
+		o.channel = channel
+		o.bindingID = bindingID
 	}
 }
 

--- a/internal/agent/sandbox/trace.go
+++ b/internal/agent/sandbox/trace.go
@@ -1,12 +1,10 @@
 package sandbox
 
 import (
-	"fmt"
-
 	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
+
+	"github.com/CherryHQ/stella/internal/observability"
 )
 
 var sandboxTracer = otel.Tracer("stella/sandbox")
@@ -15,7 +13,5 @@ func recordSandboxError(span trace.Span, err error) {
 	if span == nil || err == nil {
 		return
 	}
-	span.RecordError(err)
-	span.SetStatus(codes.Error, err.Error())
-	span.SetAttributes(attribute.String("error.type", fmt.Sprintf("%T", err)))
+	observability.RecordSpanError(span, err, "sandbox operation failed")
 }

--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -89,6 +89,10 @@ type ChatRequest struct {
 	AgentID   string
 	ProjectID string
 	Channel   session.Channel
+	// TelemetryChannel is the low-cardinality transport name. BindingID keeps
+	// the durable routing key separate from observability dimensions.
+	TelemetryChannel string
+	BindingID        string
 	// Kind overrides the default session kind (KindChat). Used by non-chat
 	// callers such as the scheduler (KindScheduler).
 	Kind    session.Kind
@@ -358,6 +362,9 @@ func (s *Service) ChatAdmitted(ctx context.Context, req ChatRequest) (<-chan Eve
 	}
 
 	opts := req.RuntimeOpts
+	if req.TelemetryChannel != "" || req.BindingID != "" {
+		opts = append(opts, agentruntime.WithTelemetryChannel(req.TelemetryChannel, req.BindingID))
+	}
 	if req.Model != "" {
 		opts = append(opts, agentruntime.WithModel(req.Model))
 	}
@@ -511,7 +518,9 @@ func (s *Service) ChatForScheduler(ctx context.Context, req SchedulerChatRequest
 		return errorEvents(fmt.Errorf("resolve scheduler session: %w", err))
 	}
 
+	ctx = agentctx.WithChannel(ctx, "scheduler")
 	var opts []agentruntime.Option
+	opts = append(opts, agentruntime.WithTelemetryChannel("scheduler", ""))
 	if req.Model != "" {
 		opts = append(opts, agentruntime.WithModel(req.Model))
 	}
@@ -579,6 +588,7 @@ func (s *Service) ChatForGoalDecomposition(ctx context.Context, req TaskChatRequ
 // ends. The per-run tools force a fresh runner that is evicted once the turn
 // finishes, so the tools never leak into later turns on the same session.
 func (s *Service) chatOnSession(ctx context.Context, sreq session.Request, req TaskChatRequest) <-chan Event {
+	ctx = agentctx.WithChannel(ctx, "goal")
 	access, err := s.beginSessionAccess(ctx, req.Authority)
 	if err != nil {
 		return errorEvents(fmt.Errorf("begin worker session access: %w", err))
@@ -588,7 +598,10 @@ func (s *Service) chatOnSession(ctx context.Context, sreq session.Request, req T
 		return errorEvents(fmt.Errorf("resolve worker session: %w", err))
 	}
 
-	opts := []agentruntime.Option{agentruntime.WithExtraTools(req.ExtraTools...)}
+	opts := []agentruntime.Option{
+		agentruntime.WithExtraTools(req.ExtraTools...),
+		agentruntime.WithTelemetryChannel("goal", ""),
+	}
 	if len(req.ExcludedTools) > 0 {
 		opts = append(opts, agentruntime.WithExcludedTools(req.ExcludedTools...))
 	}

--- a/internal/agent/session/access/runtime.go
+++ b/internal/agent/session/access/runtime.go
@@ -145,14 +145,16 @@ func (s *Service) Send(ctx, runCtx context.Context, in SendInput) (SendResult, e
 		runtimeOpts = append(runtimeOpts, agentruntime.WithExcludedTools(in.ExcludedTools...))
 	}
 	ch := runtime.Chat(runCtx, agent.ChatRequest{
-		SessionID:   in.SessionID,
-		UserID:      info.UserID,
-		AgentID:     info.AgentID,
-		Kind:        agentsession.Kind(info.Kind),
-		Channel:     agentsession.Channel(info.Channel),
-		Message:     in.Message,
-		RuntimeOpts: runtimeOpts,
-		Authority:   in.Authority,
+		SessionID:        in.SessionID,
+		UserID:           info.UserID,
+		AgentID:          info.AgentID,
+		Kind:             agentsession.Kind(info.Kind),
+		Channel:          agentsession.Channel(info.Channel),
+		TelemetryChannel: "web",
+		BindingID:        info.Channel,
+		Message:          in.Message,
+		RuntimeOpts:      runtimeOpts,
+		Authority:        in.Authority,
 	})
 	return SendResult{Events: relayEventsUntilDone(ctx, ch)}, nil
 }

--- a/internal/agent/session/access/runtime_test.go
+++ b/internal/agent/session/access/runtime_test.go
@@ -198,6 +198,9 @@ func TestSendStartsOneTurnAndChunksDoNotReevaluate(t *testing.T) {
 	if rt.chatCalls != 1 || rt.subscribeCalls != 0 {
 		t.Fatalf("chat=%d subscribe=%d, want one chat and no subscribe", rt.chatCalls, rt.subscribeCalls)
 	}
+	if len(rt.chatRequests) != 1 || rt.chatRequests[0].TelemetryChannel != "web" || rt.chatRequests[0].BindingID == "" {
+		t.Fatalf("telemetry routing = %#v, want web plus durable binding", rt.chatRequests)
+	}
 }
 
 func TestSendUsesLifecycleContextNotObserverContext(t *testing.T) {

--- a/internal/channel/coordinator.go
+++ b/internal/channel/coordinator.go
@@ -395,7 +395,7 @@ func (c *Coordinator) resolve(ctx context.Context, msg pkgchannel.IncomingMessag
 func (c *Coordinator) HandleIncoming(ctx context.Context, msg pkgchannel.IncomingMessage, command, args string) (string, bool, *pkgchannel.ChatStream, error) {
 	ctx, ingress := otel.Tracer("stella").Start(ctx, "channel.ingress",
 		trace.WithAttributes(
-			attribute.String("stella.channel.name", msg.Platform),
+			attribute.String("stella.channel.name", transportName(msg.Platform)),
 			attribute.String("stella.channel.id", msg.ChannelID),
 		))
 	defer ingress.End()
@@ -492,6 +492,13 @@ func (c *Coordinator) handleResolvedIncoming(ctx context.Context, rc *ResolvedCh
 		return "", false, nil, err
 	}
 	return "", false, stream, nil
+}
+
+func transportName(platform string) string {
+	if platform == "weixin" {
+		return "wechat"
+	}
+	return platform
 }
 
 func textOnly(content []ai.ContentBlock) bool {

--- a/internal/channel/coordinator.go
+++ b/internal/channel/coordinator.go
@@ -11,6 +11,9 @@ import (
 	"time"
 
 	"filippo.io/age"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
@@ -390,6 +393,13 @@ func (c *Coordinator) resolve(ctx context.Context, msg pkgchannel.IncomingMessag
 // command is not handled, streams a chat response. This avoids double
 // resolution when a plugin needs to try commands before messaging.
 func (c *Coordinator) HandleIncoming(ctx context.Context, msg pkgchannel.IncomingMessage, command, args string) (string, bool, *pkgchannel.ChatStream, error) {
+	ctx, ingress := otel.Tracer("stella").Start(ctx, "channel.ingress",
+		trace.WithAttributes(
+			attribute.String("stella.channel.name", msg.Platform),
+			attribute.String("stella.channel.id", msg.ChannelID),
+		))
+	defer ingress.End()
+
 	// Try link code first (before auth resolution, since it creates identity).
 	if c.auth != nil && c.linkCodes != nil {
 		fullText := command

--- a/internal/channel/coordinator.go
+++ b/internal/channel/coordinator.go
@@ -11,9 +11,7 @@ import (
 	"time"
 
 	"filippo.io/age"
-	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/trace"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
@@ -393,12 +391,16 @@ func (c *Coordinator) resolve(ctx context.Context, msg pkgchannel.IncomingMessag
 // command is not handled, streams a chat response. This avoids double
 // resolution when a plugin needs to try commands before messaging.
 func (c *Coordinator) HandleIncoming(ctx context.Context, msg pkgchannel.IncomingMessage, command, args string) (string, bool, *pkgchannel.ChatStream, error) {
-	ctx, ingress := otel.Tracer("stella").Start(ctx, "channel.ingress",
-		trace.WithAttributes(
-			attribute.String("stella.channel.name", transportName(msg.Platform)),
-			attribute.String("stella.channel.id", msg.ChannelID),
-		))
-	defer ingress.End()
+	ctx, _ = startIngress(ctx, "channel.ingress",
+		attribute.String("stella.channel.name", transportName(msg.Platform)),
+		attribute.String("stella.channel.id", msg.ChannelID),
+	)
+	handoff := false
+	defer func() {
+		if !handoff {
+			finishIngress(ctx)
+		}
+	}()
 
 	// Try link code first (before auth resolution, since it creates identity).
 	if c.auth != nil && c.linkCodes != nil {
@@ -423,7 +425,11 @@ func (c *Coordinator) HandleIncoming(ctx context.Context, msg pkgchannel.Incomin
 		return "Guest message rate limit exceeded. Try again in a minute.", true, nil, nil
 	}
 
-	return c.handleResolvedIncoming(ctx, rc, msg, command, args)
+	plain, handled, stream, err := c.handleResolvedIncoming(ctx, rc, msg, command, args)
+	if stream != nil {
+		handoff = true
+	}
+	return plain, handled, stream, err
 }
 
 func (c *Coordinator) handleResolvedIncoming(ctx context.Context, rc *ResolvedChat, msg pkgchannel.IncomingMessage, command, args string) (string, bool, *pkgchannel.ChatStream, error) {
@@ -573,7 +579,9 @@ func (c *Coordinator) handleAbort(rc *ResolvedChat) string {
 // fully drain (or abandon) Events before the queue will dispatch the next
 // request for the same session.
 func (c *Coordinator) queuedChat(ctx context.Context, rc *ResolvedChat, content []ai.ContentBlock) (*pkgchannel.ChatStream, error) {
+	markIngressQueued(ctx)
 	stream, doneC, err := c.queue.Enqueue(ctx, rc.queueKey(), func(qctx context.Context) (*pkgchannel.ChatStream, error) {
+		defer finishIngress(qctx)
 		return c.chatWithRC(qctx, rc, content)
 	})
 	if err != nil {

--- a/internal/channel/group_chat_resolver.go
+++ b/internal/channel/group_chat_resolver.go
@@ -49,6 +49,7 @@ func (r *groupChatResolver) abort(sessionKey string) bool {
 }
 
 func (r *groupChatResolver) chatDispatch(ctx context.Context, row sqlc.CtxGroupDispatch, message sqlc.CtxGroupMessage, state sqlc.CtxGroupState) (*pkgchannel.ChatStream, error) {
+	markIngressQueued(ctx)
 	sessionKey := agent.BuildGroupSessionKey(row.AgentID, row.GroupID)
 	stream, doneC, err := r.queue.Enqueue(ctx, sessionKey, func(qctx context.Context) (*pkgchannel.ChatStream, error) {
 		return r.chatDispatchUnqueued(qctx, row, message, state)
@@ -85,6 +86,7 @@ var errGroupTurnSuperseded = errors.New("group turn superseded by the agent's in
 var errGroupNudgeMoot = errors.New("group nudge became moot")
 
 func (r *groupChatResolver) chatDispatchUnqueued(ctx context.Context, row sqlc.CtxGroupDispatch, message sqlc.CtxGroupMessage, state sqlc.CtxGroupState) (*pkgchannel.ChatStream, error) {
+	defer finishIngress(ctx)
 	if row.Kind == "nudge" {
 		posted, err := r.q.AgentPostedSinceSeq(ctx, sqlc.AgentPostedSinceSeqParams{
 			GroupID: row.GroupID, AgentID: row.AgentID, AfterSeq: row.TriggerSeq,
@@ -337,17 +339,19 @@ func (r *groupChatResolver) chatWeb(ctx context.Context, row sqlc.CtxGroupDispat
 	// the same durable chat-binding marker here; without it the group turn would
 	// look like a Web send to tools that require a channel-backed chat.
 	events := rc.Service.Chat(rc.withChatBinding(ctx), agent.ChatRequest{
-		SessionID:      info.ID,
-		UserID:         row.GroupID,
-		AgentID:        row.AgentID,
-		Kind:           session.KindChat,
-		GroupID:        row.GroupID,
-		Channel:        rc.Channel,
-		Message:        agent.MessageContent(content),
-		CurrentSpeaker: speaker,
-		InputActor:     inputActor,
-		GroupWake:      memory.GroupWakeFromContext(ctx),
-		Authority:      rc.Authority,
+		SessionID:        info.ID,
+		UserID:           row.GroupID,
+		AgentID:          row.AgentID,
+		Kind:             session.KindChat,
+		GroupID:          row.GroupID,
+		Channel:          rc.Channel,
+		TelemetryChannel: "web",
+		BindingID:        string(rc.Channel),
+		Message:          agent.MessageContent(content),
+		CurrentSpeaker:   speaker,
+		InputActor:       inputActor,
+		GroupWake:        memory.GroupWakeFromContext(ctx),
+		Authority:        rc.Authority,
 	})
 	out := make(chan pkgchannel.Event, 100)
 	go func() {

--- a/internal/channel/group_dispatcher.go
+++ b/internal/channel/group_dispatcher.go
@@ -12,6 +12,9 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/CherryHQ/stella/internal/agent"
 	"github.com/CherryHQ/stella/internal/config"
@@ -520,6 +523,16 @@ func (d *GroupDispatcher) materializeWakeRows(ctx context.Context, q *sqlc.Queri
 }
 
 func (d *GroupDispatcher) ExecuteDispatch(ctx context.Context, row sqlc.CtxGroupDispatch) error {
+	ctx, ingress := otel.Tracer("stella").Start(ctx, "channel.ingress",
+		trace.WithAttributes(
+			attribute.String("stella.channel.name", "group"),
+			attribute.String("stella.channel.dispatch_id", row.ID),
+			attribute.String("stella.channel.group_id", row.GroupID),
+			attribute.String("stella.agent_id", row.AgentID),
+			attribute.String("stella.channel.dispatch_kind", row.Kind),
+		))
+	defer ingress.End()
+
 	claimed, ok, err := d.claimDispatch(ctx, row)
 	if err != nil {
 		return err

--- a/internal/channel/group_dispatcher.go
+++ b/internal/channel/group_dispatcher.go
@@ -12,9 +12,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
-	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/trace"
 
 	"github.com/CherryHQ/stella/internal/agent"
 	"github.com/CherryHQ/stella/internal/config"
@@ -523,15 +521,14 @@ func (d *GroupDispatcher) materializeWakeRows(ctx context.Context, q *sqlc.Queri
 }
 
 func (d *GroupDispatcher) ExecuteDispatch(ctx context.Context, row sqlc.CtxGroupDispatch) error {
-	ctx, ingress := otel.Tracer("stella").Start(ctx, "channel.ingress",
-		trace.WithAttributes(
-			attribute.String("stella.channel.name", "group"),
-			attribute.String("stella.channel.dispatch_id", row.ID),
-			attribute.String("stella.channel.group_id", row.GroupID),
-			attribute.String("stella.agent_id", row.AgentID),
-			attribute.String("stella.channel.dispatch_kind", row.Kind),
-		))
-	defer ingress.End()
+	ctx, _ = startIngress(ctx, "channel.ingress",
+		attribute.String("stella.channel.name", "group"),
+		attribute.String("stella.channel.dispatch_id", row.ID),
+		attribute.String("stella.channel.group_id", row.GroupID),
+		attribute.String("stella.agent_id", row.AgentID),
+		attribute.String("stella.channel.dispatch_kind", row.Kind),
+	)
+	defer finishIngress(ctx)
 
 	claimed, ok, err := d.claimDispatch(ctx, row)
 	if err != nil {

--- a/internal/channel/ingress.go
+++ b/internal/channel/ingress.go
@@ -1,0 +1,59 @@
+package channel
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type ingressContextKey struct{}
+
+type ingressSpan struct {
+	span      trace.Span
+	startedAt time.Time
+	queuedAt  time.Time
+	mu        sync.Mutex
+	once      sync.Once
+}
+
+func startIngress(ctx context.Context, name string, attrs ...attribute.KeyValue) (context.Context, *ingressSpan) {
+	ctx, span := tracer().Start(ctx, name, trace.WithAttributes(attrs...))
+	info := &ingressSpan{span: span, startedAt: time.Now()}
+	return context.WithValue(ctx, ingressContextKey{}, info), info
+}
+
+func tracer() trace.Tracer { return otel.Tracer("stella") }
+
+func markIngressQueued(ctx context.Context) {
+	info, _ := ctx.Value(ingressContextKey{}).(*ingressSpan)
+	if info == nil {
+		return
+	}
+	info.mu.Lock()
+	if info.queuedAt.IsZero() {
+		info.queuedAt = time.Now()
+	}
+	info.mu.Unlock()
+}
+
+func finishIngress(ctx context.Context) {
+	info, _ := ctx.Value(ingressContextKey{}).(*ingressSpan)
+	if info == nil {
+		return
+	}
+	info.once.Do(func() {
+		info.mu.Lock()
+		queuedAt := info.queuedAt
+		startedAt := info.startedAt
+		info.mu.Unlock()
+		if queuedAt.IsZero() {
+			queuedAt = startedAt
+		}
+		info.span.SetAttributes(attribute.Float64("stella.ingress.queue_wait_s", time.Since(queuedAt).Seconds()))
+		info.span.End()
+	})
+}

--- a/internal/channel/ingress_test.go
+++ b/internal/channel/ingress_test.go
@@ -1,0 +1,46 @@
+package channel
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+func TestIngressSpanEndsAfterQueueAdmissionBoundary(t *testing.T) {
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	previous := otel.GetTracerProvider()
+	otel.SetTracerProvider(provider)
+	t.Cleanup(func() { otel.SetTracerProvider(previous); _ = provider.Shutdown(context.Background()) })
+
+	ctx, _ := startIngress(context.Background(), "channel.ingress", attribute.String("stella.channel.name", "web"))
+	markIngressQueued(ctx)
+	time.Sleep(time.Millisecond)
+	finishIngress(ctx)
+	spans := tracetest.SpanStubsFromReadOnlySpans(recorder.Ended())
+	if len(spans) != 1 || spans[0].Name != "channel.ingress" {
+		t.Fatalf("spans = %#v", spans)
+	}
+	value, ok := spanAttribute(spans[0], "stella.ingress.queue_wait_s")
+	if !ok || value.AsFloat64() < 0 {
+		t.Fatalf("queue wait = %v (ok=%v)", value, ok)
+	}
+	finishIngress(ctx)
+	if len(recorder.Ended()) != 1 {
+		t.Fatal("ingress span ended more than once")
+	}
+}
+
+func spanAttribute(span tracetest.SpanStub, key string) (attribute.Value, bool) {
+	for _, kv := range span.Attributes {
+		if string(kv.Key) == key {
+			return kv.Value, true
+		}
+	}
+	return attribute.Value{}, false
+}

--- a/internal/channel/resolved_chat.go
+++ b/internal/channel/resolved_chat.go
@@ -177,6 +177,7 @@ func (rc *ResolvedChat) AuthorizeUse(ctx context.Context, access *agentaccess.Se
 }
 
 func (rc *ResolvedChat) Chat(ctx context.Context, message agent.MessageContent) (<-chan agent.Event, string, error) {
+	ctx = agentctx.WithChannel(ctx, rc.ChatCtx.Platform)
 	if rc.User.ID == "" && rc.GroupID == "" && rc.GuestID == "" {
 		return nil, "", fmt.Errorf("missing user context")
 	}
@@ -188,18 +189,20 @@ func (rc *ResolvedChat) Chat(ctx context.Context, message agent.MessageContent) 
 		return nil, "", fmt.Errorf("resolve session: %w", err)
 	}
 	stream := rc.Service.Chat(rc.withChatBinding(ctx), agent.ChatRequest{
-		SessionID:      info.ID,
-		UserID:         rc.sessionUserID(),
-		AgentID:        rc.AgentID,
-		Kind:           session.Kind(info.Kind),
-		GroupID:        rc.GroupID,
-		GuestID:        rc.GuestID,
-		Channel:        rc.Channel,
-		Message:        message,
-		CurrentSpeaker: rc.CurrentSpeaker,
-		InputActor:     rc.InputActor,
-		GroupWake:      rc.GroupWake,
-		Authority:      rc.Authority,
+		SessionID:        info.ID,
+		UserID:           rc.sessionUserID(),
+		AgentID:          rc.AgentID,
+		Kind:             session.Kind(info.Kind),
+		GroupID:          rc.GroupID,
+		GuestID:          rc.GuestID,
+		Channel:          rc.Channel,
+		TelemetryChannel: rc.ChatCtx.Platform,
+		BindingID:        string(rc.Channel),
+		Message:          message,
+		CurrentSpeaker:   rc.CurrentSpeaker,
+		InputActor:       rc.InputActor,
+		GroupWake:        rc.GroupWake,
+		Authority:        rc.Authority,
 	})
 	return stream, info.ID, nil
 }

--- a/internal/channel/resolved_chat.go
+++ b/internal/channel/resolved_chat.go
@@ -177,7 +177,7 @@ func (rc *ResolvedChat) AuthorizeUse(ctx context.Context, access *agentaccess.Se
 }
 
 func (rc *ResolvedChat) Chat(ctx context.Context, message agent.MessageContent) (<-chan agent.Event, string, error) {
-	ctx = agentctx.WithChannel(ctx, rc.ChatCtx.Platform)
+	ctx = agentctx.WithChannel(ctx, transportName(rc.ChatCtx.Platform))
 	if rc.User.ID == "" && rc.GroupID == "" && rc.GuestID == "" {
 		return nil, "", fmt.Errorf("missing user context")
 	}
@@ -196,7 +196,7 @@ func (rc *ResolvedChat) Chat(ctx context.Context, message agent.MessageContent) 
 		GroupID:          rc.GroupID,
 		GuestID:          rc.GuestID,
 		Channel:          rc.Channel,
-		TelemetryChannel: rc.ChatCtx.Platform,
+		TelemetryChannel: transportName(rc.ChatCtx.Platform),
 		BindingID:        string(rc.Channel),
 		Message:          message,
 		CurrentSpeaker:   rc.CurrentSpeaker,

--- a/internal/config/env_scan_test.go
+++ b/internal/config/env_scan_test.go
@@ -81,6 +81,10 @@ var envReadAllowlist = map[string]map[string]bool{
 		nonLiteralRead:                true,
 	},
 
+	// Query tracing is a deliberate opt-in local to pgx: it is disabled by
+	// default because per-query spans are high-volume and include db.statement.
+	"internal/db/database.go": {"OTEL_STELLA_RECORD_DB_QUERIES": true},
+
 	// Per-request: trusted-proxy CIDRs are consulted on every inbound request to
 	// resolve the client IP, not cached at boot.
 	"internal/server/oidc.go": {"STELLA_TRUSTED_PROXIES": true},

--- a/internal/config/env_scan_test.go
+++ b/internal/config/env_scan_test.go
@@ -70,6 +70,7 @@ var envReadAllowlist = map[string]map[string]bool{
 	// agree; the exporter connection details stay with the setup that uses
 	// them.
 	"internal/observability/observability.go": {
+		"LOG_LEVEL":                   true,
 		"OTEL_EXPORTER_OTLP_ENDPOINT": true,
 		"OTEL_EXPORTER_OTLP_INSECURE": true,
 		"OTEL_SERVICE_NAME":           true,

--- a/internal/db/database.go
+++ b/internal/db/database.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -17,8 +18,9 @@ import (
 	"github.com/pressly/goose/v3"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
+
+	"github.com/CherryHQ/stella/internal/observability"
 )
 
 // migrateLockKey is an arbitrary but stable 64-bit key for the advisory lock
@@ -179,7 +181,7 @@ type spanCtxKey struct{}
 type queryTracer struct{}
 
 func (queryTracer) TraceQueryStart(ctx context.Context, _ *pgx.Conn, data pgx.TraceQueryStartData) context.Context {
-	if !trace.SpanContextFromContext(ctx).IsValid() {
+	if os.Getenv("OTEL_STELLA_RECORD_DB_QUERIES") != "true" || !trace.SpanContextFromContext(ctx).IsValid() {
 		return ctx
 	}
 	ctx, span := otel.Tracer("github.com/CherryHQ/stella/internal/db").Start(
@@ -200,8 +202,7 @@ func (queryTracer) TraceQueryEnd(ctx context.Context, _ *pgx.Conn, data pgx.Trac
 	}
 	// pgx.ErrNoRows is an ordinary "not found", not a query failure.
 	if data.Err != nil && !errors.Is(data.Err, pgx.ErrNoRows) {
-		span.RecordError(data.Err)
-		span.SetStatus(codes.Error, data.Err.Error())
+		observability.RecordSpanError(span, data.Err, "db query failed")
 	}
 	span.End()
 }

--- a/internal/db/database_test.go
+++ b/internal/db/database_test.go
@@ -7,7 +7,12 @@ import (
 	"strings"
 	"testing"
 
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/jackc/pgx/v5/stdlib"
@@ -15,6 +20,26 @@ import (
 
 	"github.com/CherryHQ/stella/internal/manifestplugins"
 )
+
+func TestQueryTracerIsOptIn(t *testing.T) {
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	previous := otel.GetTracerProvider()
+	otel.SetTracerProvider(provider)
+	t.Cleanup(func() { otel.SetTracerProvider(previous); _ = provider.Shutdown(context.Background()) })
+	ctx, parent := otel.Tracer("test").Start(context.Background(), "parent")
+	defer parent.End()
+	data := pgx.TraceQueryStartData{SQL: "SELECT 1"}
+	t.Setenv("OTEL_STELLA_RECORD_DB_QUERIES", "false")
+	if got := (queryTracer{}).TraceQueryStart(ctx, nil, data); got.Value(spanCtxKey{}) != nil {
+		t.Fatal("query span created while query tracing was disabled")
+	}
+	t.Setenv("OTEL_STELLA_RECORD_DB_QUERIES", "true")
+	queryCtx := (queryTracer{}).TraceQueryStart(ctx, nil, data)
+	if queryCtx.Value(spanCtxKey{}) == nil {
+		t.Fatal("query span missing when query tracing was enabled")
+	}
+}
 
 func TestOpenDBFreshInstallDoesNotCreateFeishuTokensTable(t *testing.T) {
 	t.Parallel()

--- a/internal/goal/worker.go
+++ b/internal/goal/worker.go
@@ -9,6 +9,9 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/CherryHQ/stella/pkg/db/pgnull"
 	"github.com/CherryHQ/stella/pkg/db/sqlc"
@@ -82,6 +85,12 @@ func (w *Worker) SetLease(d time.Duration) { w.lease = d }
 //     transition so convergence can mint the next attempt or block;
 //   - turn an executor panic into a non-retryable failure.
 func (w *Worker) Run(ctx context.Context, goalID, attemptID string, actor Actor) (err error) {
+	ctx, attemptSpan := otel.Tracer("stella").Start(ctx, "goal.attempt",
+		trace.WithAttributes(
+			attribute.String("stella.goal.id", goalID),
+			attribute.String("stella.goal.attempt_id", attemptID),
+		))
+	defer attemptSpan.End()
 	att, err := w.q.GetAttempt(ctx, attemptID)
 	if err != nil {
 		return fmt.Errorf("worker: load attempt: %w", err)
@@ -90,6 +99,11 @@ func (w *Worker) Run(ctx context.Context, goalID, attemptID string, actor Actor)
 	if err != nil {
 		return fmt.Errorf("worker: load goal: %w", err)
 	}
+	attemptSpan.SetAttributes(
+		attribute.String("stella.goal.purpose", att.Purpose),
+		attribute.String("stella.goal.agent_id", att.AgentID.String),
+		attribute.String("stella.goal.executor_agent_id", att.ExecutorAgentID.String),
+	)
 
 	if err := w.svc.promoteAttempt(ctx, attemptID, w.leaseUntil()); err != nil {
 		if errors.Is(err, ErrInvalidTransition) {

--- a/internal/goal/worker.go
+++ b/internal/goal/worker.go
@@ -13,6 +13,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/CherryHQ/stella/internal/observability"
 	"github.com/CherryHQ/stella/pkg/db/pgnull"
 	"github.com/CherryHQ/stella/pkg/db/sqlc"
 	"github.com/CherryHQ/stella/pkg/sandbox"
@@ -124,7 +125,8 @@ func (w *Worker) Run(ctx context.Context, goalID, attemptID string, actor Actor)
 		hbCancel()
 		hbWG.Wait()
 		if r := recover(); r != nil {
-			w.log.Error("worker executor panicked", "goal_id", goalID, "attempt_id", attemptID, "panic", r)
+			w.log.Error("worker executor panicked", "goal_id", goalID, "attempt_id", attemptID, "error.type", fmt.Sprintf("%T", r), "error.class", "executor_panic")
+			observability.ConsoleOnlyLogger().Error("worker executor panic detail", "goal_id", goalID, "attempt_id", attemptID, "panic", r)
 			w.failAttempt(goalID, attemptID, fmt.Sprintf("executor panic: %v", r), FailureClassEnvironment, BlockEnvUnavailable)
 			err = fmt.Errorf("executor panic: %v", r)
 		}
@@ -148,17 +150,17 @@ func (w *Worker) Run(ctx context.Context, goalID, attemptID string, actor Actor)
 		}
 		// The executor encodes outcomes in its Result; a returned error is
 		// unexpected. Record it as a failed attempt so convergence can recover.
-		w.log.Warn("worker: executor returned error", "goal_id", goalID, "attempt_id", attemptID, "err", eerr)
+		w.log.Warn("worker: executor returned error", "goal_id", goalID, "attempt_id", attemptID, "error.type", fmt.Sprintf("%T", eerr), "error.class", "worker_executor_error")
 		res = ExecutorResult{Failed: true, FailReason: fmt.Sprintf("executor error: %v", eerr), FailureClass: FailureClassFlaky}
 	}
-	return w.applyResult(goalID, goal, att, actor, res, checksRan, checkErr)
+	return w.applyResult(ctx, goalID, goal, att, actor, res, checksRan, checkErr)
 }
 
 // applyResult maps the executor's Result to the SINGLE durable transition. A
 // fresh context is used so the outcome is recorded even if the dispatch context
 // was cancelled (e.g. on shutdown).
-func (w *Worker) applyResult(goalID string, goal sqlc.AgentGoal, att sqlc.AgentGoalAttempt, actor Actor, res ExecutorResult, checksRan bool, checkErr error) error {
-	ctx := context.Background()
+func (w *Worker) applyResult(ctx context.Context, goalID string, goal sqlc.AgentGoal, att sqlc.AgentGoalAttempt, actor Actor, res ExecutorResult, checksRan bool, checkErr error) error {
+	ctx = context.WithoutCancel(ctx)
 
 	switch {
 	case att.Purpose == PurposeDecomposition:
@@ -242,7 +244,7 @@ func (w *Worker) applyDecompositionResult(ctx context.Context, goal sqlc.AgentGo
 						input.PriorErrors = errs
 						next, eerr := w.exec.Execute(ctx, ExecutorRequest{Goal: goal, Attempt: att, Input: input})
 						if eerr != nil {
-							w.log.Warn("worker: planner repair executor returned error", "goal_id", goal.ID, "attempt_id", att.ID, "err", eerr)
+							w.log.Warn("worker: planner repair executor returned error", "goal_id", goal.ID, "attempt_id", att.ID, "error.type", fmt.Sprintf("%T", eerr), "error.class", "worker_executor_error")
 							res = ExecutorResult{Failed: true, FailReason: fmt.Sprintf("executor error: %v", eerr), FailureClass: FailureClassFlaky}
 						} else {
 							res = next
@@ -273,7 +275,7 @@ func (w *Worker) recordRepairRounds(ctx context.Context, goalID, attemptID strin
 		repairs = 0
 	}
 	if err := w.q.SetAttemptRepairRounds(ctx, sqlc.SetAttemptRepairRoundsParams{ID: attemptID, RepairRounds: int32(repairs)}); err != nil {
-		w.log.Warn("worker: record repair rounds failed", "goal_id", goalID, "attempt_id", attemptID, "repair_rounds", repairs, "err", err)
+		w.log.Warn("worker: record repair rounds failed", "goal_id", goalID, "attempt_id", attemptID, "repair_rounds", repairs, "error.type", fmt.Sprintf("%T", err), "error.class", "worker_operation_error")
 	}
 }
 
@@ -340,7 +342,7 @@ func (w *Worker) runChecks(ctx context.Context, goal sqlc.AgentGoal, att sqlc.Ag
 	if err := unmarshalJSON(goal.AcceptanceContract, &contract); err != nil {
 		// An unparseable contract has no runnable checks; the fold treats it as
 		// trivial. Don't fail the attempt on a malformed column.
-		w.log.Warn("worker: unmarshal contract for checks failed", "goal_id", goal.ID, "err", err)
+		w.log.Warn("worker: unmarshal contract for checks failed", "goal_id", goal.ID, "error.type", fmt.Sprintf("%T", err), "error.class", "worker_operation_error")
 		return nil
 	}
 	required := requiredDeterministicItems(contract)
@@ -420,7 +422,7 @@ func (w *Worker) appendCheckEvent(ctx context.Context, goalID, attemptID string,
 		return e
 	})
 	if err != nil {
-		w.log.Warn("worker: append check acceptance_event failed", "goal_id", goalID, "item_id", item.ID, "err", err)
+		w.log.Warn("worker: append check acceptance_event failed", "goal_id", goalID, "item_id", item.ID, "error.type", fmt.Sprintf("%T", err), "error.class", "worker_operation_error")
 	}
 	return err
 }
@@ -434,7 +436,7 @@ func (w *Worker) checkEnv(ctx context.Context, goal sqlc.AgentGoal) CheckEnv {
 	env := CheckEnv{GoalID: goal.ID}
 	edges, err := w.q.ListEdgeWithUpstreamState(ctx, goal.ID)
 	if err != nil {
-		w.log.Warn("worker: list upstream edges for check env failed", "goal_id", goal.ID, "err", err)
+		w.log.Warn("worker: list upstream edges for check env failed", "goal_id", goal.ID, "error.type", fmt.Sprintf("%T", err), "error.class", "worker_operation_error")
 		return env
 	}
 	for _, e := range edges {
@@ -456,7 +458,7 @@ func (w *Worker) checkEnv(ctx context.Context, goal sqlc.AgentGoal) CheckEnv {
 func (w *Worker) attemptInput(att sqlc.AgentGoalAttempt) AttemptInput {
 	var in AttemptInput
 	if err := unmarshalJSON(att.InputContext, &in); err != nil {
-		w.log.Warn("worker: decode attempt input_context failed", "attempt_id", att.ID, "err", err)
+		w.log.Warn("worker: decode attempt input_context failed", "attempt_id", att.ID, "error.type", fmt.Sprintf("%T", err), "error.class", "worker_operation_error")
 	}
 	in.AttemptNo = int(att.AttemptNo)
 	return in
@@ -471,7 +473,7 @@ func (w *Worker) attemptInput(att sqlc.AgentGoalAttempt) AttemptInput {
 func (w *Worker) failAttempt(goalID, attemptID, reason, failureClass string, blockedBy ...string) {
 	ctx := context.Background()
 	if err := w.svc.FailAttempt(ctx, attemptID, reason, failureClass, blockedBy...); err != nil && !errors.Is(err, ErrInvalidTransition) {
-		w.log.Warn("worker: finalize failed attempt failed", "goal_id", goalID, "attempt_id", attemptID, "err", err)
+		w.log.Warn("worker: finalize failed attempt failed", "goal_id", goalID, "attempt_id", attemptID, "error.type", fmt.Sprintf("%T", err), "error.class", "worker_operation_error")
 	}
 }
 
@@ -511,7 +513,7 @@ func (w *Worker) heartbeatLoop(ctx context.Context, wg *sync.WaitGroup, attemptI
 			if err != nil {
 				// A missed beat (e.g. a transient DB error) silently shortens the lease;
 				// log it so a lease expiry can be traced to a failed heartbeat.
-				w.log.Warn("worker: heartbeat write failed", "attempt_id", attemptID, "err", err)
+				w.log.Warn("worker: heartbeat write failed", "attempt_id", attemptID, "error.type", fmt.Sprintf("%T", err), "error.class", "worker_operation_error")
 				continue
 			}
 			if n == 0 {

--- a/internal/llmusage/hook.go
+++ b/internal/llmusage/hook.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
@@ -32,6 +33,8 @@ type Hook struct {
 	mu      sync.RWMutex
 	closed  bool
 	pending map[string]int64
+	dropped atomic.Int64
+	onDrop  func()
 }
 
 func New(db *pgxpool.Pool) *Hook {
@@ -46,6 +49,16 @@ func New(db *pgxpool.Pool) *Hook {
 
 func (*Hook) Name() string  { return "llm_usage" }
 func (*Hook) Priority() int { return 10 }
+
+// SetDropObserver installs a non-blocking callback for queue drops.
+func (h *Hook) SetDropObserver(fn func()) {
+	h.mu.Lock()
+	h.onDrop = fn
+	h.mu.Unlock()
+}
+
+func (h *Hook) QueueDepth() int     { return len(h.jobs) }
+func (h *Hook) DroppedCount() int64 { return h.dropped.Load() }
 
 // Start owns the one background writer for this process-lifetime core hook.
 func (h *Hook) Start() {
@@ -83,7 +96,11 @@ func (h *Hook) OnPostLLMCall(_ context.Context, hctx *hooks.PostLLMCallContext) 
 	case h.jobs <- job:
 		h.pending[job.SessionID]++
 	default:
+		h.dropped.Add(1)
 		h.log.Warn("llm usage queue full; dropping observation", "session_id", hctx.SessionID, "agent_id", hctx.AgentID)
+		if h.onDrop != nil {
+			h.onDrop()
+		}
 	}
 }
 

--- a/internal/memory/traced.go
+++ b/internal/memory/traced.go
@@ -57,6 +57,15 @@ func (t *tracedProvider) hooks() *hooks.HookSet {
 }
 
 func (t *tracedProvider) begin(ctx context.Context, hctx *hooks.PostMemoryCallContext) (context.Context, time.Time) {
+	if hctx.Channel == "" || hctx.BindingID == "" {
+		channel, bindingID := hooks.TelemetryMetaFromContext(ctx)
+		if hctx.Channel == "" {
+			hctx.Channel = channel
+		}
+		if hctx.BindingID == "" {
+			hctx.BindingID = bindingID
+		}
+	}
 	if authz.GuestIDFromContext(ctx) != "" {
 		return ctx, time.Now()
 	}
@@ -64,7 +73,7 @@ func (t *tracedProvider) begin(ctx context.Context, hctx *hooks.PostMemoryCallCo
 	if hs == nil || hs.Empty() {
 		return ctx, time.Now()
 	}
-	preResult, _ := hs.RunPreMemoryCall(ctx, &hooks.PreMemoryCallContext{
+	preResult := hs.RunPreMemoryCall(ctx, &hooks.PreMemoryCallContext{
 		HookMeta:  hctx.HookMeta,
 		Op:        hctx.Op,
 		SessionID: hctx.SessionID,
@@ -97,6 +106,7 @@ func metaFromSession(s Session) hooks.HookMeta {
 		SessionID: s.ID,
 		UserID:    s.UserID,
 		AgentID:   s.AgentID,
+		Channel:   s.Channel,
 	}
 }
 

--- a/internal/memory/traced.go
+++ b/internal/memory/traced.go
@@ -57,14 +57,12 @@ func (t *tracedProvider) hooks() *hooks.HookSet {
 }
 
 func (t *tracedProvider) begin(ctx context.Context, hctx *hooks.PostMemoryCallContext) (context.Context, time.Time) {
-	if hctx.Channel == "" || hctx.BindingID == "" {
-		channel, bindingID := hooks.TelemetryMetaFromContext(ctx)
-		if hctx.Channel == "" {
-			hctx.Channel = channel
-		}
-		if hctx.BindingID == "" {
-			hctx.BindingID = bindingID
-		}
+	channel, bindingID := hooks.TelemetryMetaFromContext(ctx)
+	if channel != "" {
+		hctx.Channel = channel
+	}
+	if bindingID != "" {
+		hctx.BindingID = bindingID
 	}
 	if authz.GuestIDFromContext(ctx) != "" {
 		return ctx, time.Now()

--- a/internal/observability/metrichook/hook.go
+++ b/internal/observability/metrichook/hook.go
@@ -1,0 +1,248 @@
+// Package metrichook records bounded agent-loop metrics from the core hook
+// payloads. It has no session state and never uses session or user identifiers
+// as metric labels.
+package metrichook
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/CherryHQ/stella/pkg/ai"
+	"github.com/CherryHQ/stella/pkg/hooks"
+)
+
+type QueueStats interface {
+	QueueDepth() int
+	DroppedCount() int64
+}
+
+type Hook struct {
+	queue   QueueStats
+	active  func() int64
+	mu      sync.Mutex
+	bound   bool
+	metrics metrics
+}
+
+type metrics struct {
+	llmDuration, llmTTFT, toolDuration, turnDuration, memoryDuration metric.Float64Histogram
+	llmTokens, llmCalls, llmAttempts, toolCalls, agentTurns          metric.Int64Counter
+	llmCost                                                          metric.Float64Counter
+	queueDropped                                                     metric.Int64Counter
+	queueDepth, activeSessions                                       metric.Int64ObservableGauge
+	callback                                                         metric.Registration
+}
+
+func New(queue QueueStats, activeSessions func() int64) *Hook {
+	return &Hook{queue: queue, active: activeSessions}
+}
+
+func (h *Hook) Name() string  { return "metrics" }
+func (h *Hook) Priority() int { return 20 }
+
+// Bind creates instruments against the already-installed global provider. It
+// must happen after observability.Init, otherwise instruments bind to noop.
+func (h *Hook) Bind(meter metric.Meter) error {
+	if h == nil {
+		return errors.New("metrics hook is nil")
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.bound {
+		return errors.New("metrics hook already bound")
+	}
+	if meter == nil {
+		return errors.New("metrics meter is nil")
+	}
+	var err error
+	newHistogram := func(name, unit string) metric.Float64Histogram {
+		if err != nil {
+			return nil
+		}
+		var out metric.Float64Histogram
+		out, err = meter.Float64Histogram(name, metric.WithUnit(unit))
+		return out
+	}
+	newCounter := func(name, unit string) metric.Int64Counter {
+		if err != nil {
+			return nil
+		}
+		var out metric.Int64Counter
+		out, err = meter.Int64Counter(name, metric.WithUnit(unit))
+		return out
+	}
+	newFloatCounter := func(name, unit string) metric.Float64Counter {
+		if err != nil {
+			return nil
+		}
+		var out metric.Float64Counter
+		out, err = meter.Float64Counter(name, metric.WithUnit(unit))
+		return out
+	}
+	h.metrics.llmDuration = newHistogram("stella.llm.call.duration", "s")
+	h.metrics.llmTTFT = newHistogram("stella.llm.time_to_first_token", "s")
+	h.metrics.toolDuration = newHistogram("stella.tool.call.duration", "s")
+	h.metrics.turnDuration = newHistogram("stella.agent.turn.duration", "s")
+	h.metrics.memoryDuration = newHistogram("stella.memory.op.duration", "s")
+	h.metrics.llmTokens = newCounter("stella.llm.tokens", "token")
+	h.metrics.llmCalls = newCounter("stella.llm.calls", "{call}")
+	h.metrics.llmAttempts = newCounter("stella.llm.attempts", "{attempt}")
+	h.metrics.toolCalls = newCounter("stella.tool.calls", "{call}")
+	h.metrics.agentTurns = newCounter("stella.agent.turns", "{turn}")
+	h.metrics.queueDropped = newCounter("stella.llm_usage.queue.dropped", "{observation}")
+	h.metrics.llmCost = newFloatCounter("stella.llm.cost", "USD")
+	if err != nil {
+		return err
+	}
+	var gaugeErr error
+	h.metrics.queueDepth, gaugeErr = meter.Int64ObservableGauge("stella.llm_usage.queue.depth", metric.WithUnit("{observation}"))
+	if gaugeErr != nil {
+		return gaugeErr
+	}
+	h.metrics.activeSessions, gaugeErr = meter.Int64ObservableGauge("stella.trace.sessions.active", metric.WithUnit("{session}"))
+	if gaugeErr != nil {
+		return gaugeErr
+	}
+	h.metrics.callback, gaugeErr = meter.RegisterCallback(func(_ context.Context, o metric.Observer) error {
+		if h.queue != nil {
+			o.ObserveInt64(h.metrics.queueDepth, int64(h.queue.QueueDepth()))
+		}
+		if h.active != nil {
+			o.ObserveInt64(h.metrics.activeSessions, h.active())
+		}
+		return nil
+	}, h.metrics.queueDepth, h.metrics.activeSessions)
+	if gaugeErr != nil {
+		return gaugeErr
+	}
+	h.bound = true
+	return nil
+}
+
+func (h *Hook) ready() bool {
+	if h == nil {
+		return false
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.bound
+}
+
+func (h *Hook) RecordQueueDrop() {
+	if h == nil {
+		return
+	}
+	h.mu.Lock()
+	bound := h.bound
+	counter := h.metrics.queueDropped
+	h.mu.Unlock()
+	if bound {
+		counter.Add(context.Background(), 1)
+	}
+}
+
+func attrs(values ...attribute.KeyValue) metric.MeasurementOption {
+	return metric.WithAttributes(values...)
+}
+
+func common(meta hooks.HookMeta) []attribute.KeyValue {
+	out := make([]attribute.KeyValue, 0, 3)
+	if meta.AgentID != "" {
+		out = append(out, attribute.String("agent_id", meta.AgentID))
+	}
+	if meta.Channel != "" {
+		out = append(out, attribute.String("channel", channel(meta.Channel)))
+	}
+	return out
+}
+
+func channel(value string) string {
+	switch value {
+	case "web", "telegram", "feishu", "discord", "qq", "wechat", "scheduler", "goal":
+		return value
+	default:
+		return "other"
+	}
+}
+
+func errorType(err error) string {
+	if err == nil {
+		return "none"
+	}
+	return fmt.Sprintf("%T", err)
+}
+
+func toolErrorKind(kind ai.ToolErrorKind, isError bool) string {
+	if !isError {
+		return "none"
+	}
+	if kind == "" {
+		return string(ai.ToolErrorKindTool)
+	}
+	return string(kind)
+}
+
+func (h *Hook) OnPostLLMCall(ctx context.Context, c *hooks.PostLLMCallContext) {
+	if !h.ready() {
+		return
+	}
+	base := common(c.HookMeta)
+	base = append(base, attribute.String("model", c.Model), attribute.String("provider", c.Provider))
+	h.metrics.llmDuration.Record(ctx, c.Duration.Seconds(), attrs(base...))
+	if c.TimeToFirstToken > 0 {
+		h.metrics.llmTTFT.Record(ctx, c.TimeToFirstToken.Seconds(), attrs(base...))
+	}
+	h.metrics.llmCalls.Add(ctx, 1, attrs(append(base, attribute.String("stop_reason", string(c.StopReason)), attribute.String("error.type", errorType(c.Error)))...))
+	if c.Attempts > 0 {
+		h.metrics.llmAttempts.Add(ctx, int64(c.Attempts), attrs(base...))
+	}
+	for kind, value := range map[string]int64{"input": int64(c.Usage.InputTokens), "output": int64(c.Usage.OutputTokens), "cache_read": int64(c.Usage.CacheRead), "cache_write": int64(c.Usage.CacheWrite)} {
+		if value > 0 {
+			h.metrics.llmTokens.Add(ctx, value, attrs(append(base, attribute.String("type", kind))...))
+		}
+	}
+	if c.Usage.CostConfigured && c.Usage.Cost.Total > 0 {
+		h.metrics.llmCost.Add(ctx, c.Usage.Cost.Total, attrs(base...))
+	}
+}
+
+func (h *Hook) OnPostToolCall(ctx context.Context, c *hooks.PostToolCallContext) {
+	if !h.ready() {
+		return
+	}
+	base := common(c.HookMeta)
+	base = append(base, attribute.String("tool", c.ToolName), attribute.Bool("is_error", c.IsError), attribute.String("error_kind", toolErrorKind(c.ErrorKind, c.IsError)))
+	h.metrics.toolDuration.Record(ctx, c.Duration.Seconds(), attrs(base...))
+	h.metrics.toolCalls.Add(ctx, 1, attrs(base...))
+}
+
+func (h *Hook) OnPostAgentCall(ctx context.Context, c *hooks.PostAgentCallContext) {
+	if !h.ready() {
+		return
+	}
+	base := common(c.HookMeta)
+	h.metrics.turnDuration.Record(ctx, c.Duration.Seconds(), attrs(base...))
+	h.metrics.agentTurns.Add(ctx, 1, attrs(append(base, attribute.String("error.type", errorType(c.Error)))...))
+}
+
+func (h *Hook) OnPostMemoryCall(ctx context.Context, c *hooks.PostMemoryCallContext) {
+	if !h.ready() {
+		return
+	}
+	base := common(c.HookMeta)
+	base = append(base, attribute.String("op", string(c.Op)))
+	h.metrics.memoryDuration.Record(ctx, c.Duration.Seconds(), attrs(base...))
+}
+
+var (
+	_ hooks.HookPlugin         = (*Hook)(nil)
+	_ hooks.PostLLMCallHook    = (*Hook)(nil)
+	_ hooks.PostToolCallHook   = (*Hook)(nil)
+	_ hooks.PostAgentCallHook  = (*Hook)(nil)
+	_ hooks.PostMemoryCallHook = (*Hook)(nil)
+)

--- a/internal/observability/metrichook/hook.go
+++ b/internal/observability/metrichook/hook.go
@@ -22,11 +22,12 @@ type QueueStats interface {
 }
 
 type Hook struct {
-	queue   QueueStats
-	active  func() int64
-	mu      sync.Mutex
-	bound   bool
-	metrics metrics
+	queue     QueueStats
+	active    func() int64
+	knownTool func(string) bool
+	mu        sync.Mutex
+	bound     bool
+	metrics   metrics
 }
 
 type metrics struct {
@@ -38,8 +39,12 @@ type metrics struct {
 	callback                                                         metric.Registration
 }
 
-func New(queue QueueStats, activeSessions func() int64) *Hook {
-	return &Hook{queue: queue, active: activeSessions}
+func New(queue QueueStats, activeSessions func() int64, knownTool ...func(string) bool) *Hook {
+	var known func(string) bool
+	if len(knownTool) > 0 {
+		known = knownTool[0]
+	}
+	return &Hook{queue: queue, active: activeSessions, knownTool: known}
 }
 
 func (h *Hook) Name() string  { return "metrics" }
@@ -179,6 +184,16 @@ func errorType(err error) string {
 	return fmt.Sprintf("%T", err)
 }
 
+func (h *Hook) toolName(name string) string {
+	if name == "bash" || name == "code" || name == "memory_read" || name == "memory_search" || name == "skill_load" || name == "view_image" {
+		return name
+	}
+	if h.knownTool != nil && h.knownTool(name) {
+		return name
+	}
+	return "<unknown>"
+}
+
 func toolErrorKind(kind ai.ToolErrorKind, isError bool) string {
 	if !isError {
 		return "none"
@@ -195,7 +210,8 @@ func (h *Hook) OnPostLLMCall(ctx context.Context, c *hooks.PostLLMCallContext) {
 	}
 	base := common(c.HookMeta)
 	base = append(base, attribute.String("model", c.Model), attribute.String("provider", c.Provider))
-	h.metrics.llmDuration.Record(ctx, c.Duration.Seconds(), attrs(base...))
+	durationAttrs := append(append([]attribute.KeyValue(nil), base...), attribute.String("error.type", errorType(c.Error)))
+	h.metrics.llmDuration.Record(ctx, c.Duration.Seconds(), attrs(durationAttrs...))
 	if c.TimeToFirstToken > 0 {
 		h.metrics.llmTTFT.Record(ctx, c.TimeToFirstToken.Seconds(), attrs(base...))
 	}
@@ -218,7 +234,7 @@ func (h *Hook) OnPostToolCall(ctx context.Context, c *hooks.PostToolCallContext)
 		return
 	}
 	base := common(c.HookMeta)
-	base = append(base, attribute.String("tool", c.ToolName), attribute.Bool("is_error", c.IsError), attribute.String("error_kind", toolErrorKind(c.ErrorKind, c.IsError)))
+	base = append(base, attribute.String("tool", h.toolName(c.ToolName)), attribute.Bool("is_error", c.IsError), attribute.String("error_kind", toolErrorKind(c.ErrorKind, c.IsError)))
 	h.metrics.toolDuration.Record(ctx, c.Duration.Seconds(), attrs(base...))
 	h.metrics.toolCalls.Add(ctx, 1, attrs(base...))
 }

--- a/internal/observability/metrichook/hook.go
+++ b/internal/observability/metrichook/hook.go
@@ -165,6 +165,8 @@ func channel(value string) string {
 	switch value {
 	case "web", "telegram", "feishu", "discord", "qq", "wechat", "scheduler", "goal":
 		return value
+	case "weixin":
+		return "wechat"
 	default:
 		return "other"
 	}

--- a/internal/observability/metrichook/hook_test.go
+++ b/internal/observability/metrichook/hook_test.go
@@ -78,6 +78,23 @@ func assertNoForbiddenLabels(t *testing.T, rm metricdata.ResourceMetrics) {
 	}
 }
 
+func firstHistogramPoint(t *testing.T, m metricdata.Metrics) metricdata.HistogramDataPoint[float64] {
+	t.Helper()
+	data, ok := m.Data.(metricdata.Histogram[float64])
+	if !ok || len(data.DataPoints) != 1 {
+		t.Fatalf("metric %q data = %#v", m.Name, m.Data)
+	}
+	return data.DataPoints[0]
+}
+
+func labelKeys(set attribute.Set) map[string]bool {
+	out := map[string]bool{}
+	for _, kv := range set.ToSlice() {
+		out[string(kv.Key)] = true
+	}
+	return out
+}
+
 func TestHookRecordsCoreInstrumentsAndBoundedLabels(t *testing.T) {
 	reader := metric.NewManualReader()
 	provider := metric.NewMeterProvider(metric.WithReader(reader))
@@ -118,6 +135,46 @@ func TestHookRecordsCoreInstrumentsAndBoundedLabels(t *testing.T) {
 		}
 	}
 	assertNoForbiddenLabels(t, rm)
+	duration := firstHistogramPoint(t, names["stella.llm.call.duration"])
+	if duration.Count != 1 || duration.Sum != 2 {
+		t.Fatalf("duration point = %+v", duration)
+	}
+	wantLabels := map[string]bool{"agent_id": true, "channel": true, "model": true, "provider": true, "error.type": true}
+	gotLabels := labelKeys(duration.Attributes)
+	if len(gotLabels) != len(wantLabels) {
+		t.Fatalf("duration labels = %v, want %v", gotLabels, wantLabels)
+	}
+	for key := range wantLabels {
+		if !gotLabels[key] {
+			t.Fatalf("duration labels missing %q: %v", key, gotLabels)
+		}
+	}
+	if data, ok := names["stella.llm_usage.queue.depth"].Data.(metricdata.Gauge[int64]); !ok || len(data.DataPoints) != 1 || data.DataPoints[0].Value != 7 {
+		t.Fatalf("queue depth = %#v", names["stella.llm_usage.queue.depth"].Data)
+	}
+	if data, ok := names["stella.llm_usage.queue.dropped"].Data.(metricdata.Sum[int64]); !ok || len(data.DataPoints) != 1 || data.DataPoints[0].Value != 1 {
+		t.Fatalf("queue dropped = %#v", names["stella.llm_usage.queue.dropped"].Data)
+	}
+}
+
+func TestHookUnknownToolUsesStableLabel(t *testing.T) {
+	reader := metric.NewManualReader()
+	provider := metric.NewMeterProvider(metric.WithReader(reader))
+	defer func() { _ = provider.Shutdown(context.Background()) }()
+	h := New(nil, nil)
+	if err := h.Bind(provider.Meter("stella")); err != nil {
+		t.Fatal(err)
+	}
+	h.OnPostToolCall(context.Background(), &hooks.PostToolCallContext{ToolName: "forged-name", Duration: time.Second})
+	rm := collect(t, reader)
+	m := metricNames(rm)["stella.tool.calls"]
+	data, ok := m.Data.(metricdata.Sum[int64])
+	if !ok || len(data.DataPoints) != 1 {
+		t.Fatalf("tool calls = %#v", m.Data)
+	}
+	if got, ok := data.DataPoints[0].Attributes.Value("tool"); !ok || got.AsString() != "<unknown>" {
+		t.Fatalf("tool label = %v (ok=%v)", got, ok)
+	}
 }
 
 func TestHookBindIsExplicitAndOnlyOnce(t *testing.T) {

--- a/internal/observability/metrichook/hook_test.go
+++ b/internal/observability/metrichook/hook_test.go
@@ -1,0 +1,137 @@
+package metrichook
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/CherryHQ/stella/pkg/ai"
+	"github.com/CherryHQ/stella/pkg/hooks"
+)
+
+type queueStats struct{ depth int }
+
+func (q queueStats) QueueDepth() int     { return q.depth }
+func (q queueStats) DroppedCount() int64 { return 0 }
+
+func collect(t *testing.T, reader *metric.ManualReader) metricdata.ResourceMetrics {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatal(err)
+	}
+	return rm
+}
+
+func metricNames(rm metricdata.ResourceMetrics) map[string]metricdata.Metrics {
+	out := map[string]metricdata.Metrics{}
+	for _, scope := range rm.ScopeMetrics {
+		for _, m := range scope.Metrics {
+			out[m.Name] = m
+		}
+	}
+	return out
+}
+
+func assertNoForbiddenLabels(t *testing.T, rm metricdata.ResourceMetrics) {
+	t.Helper()
+	for _, scope := range rm.ScopeMetrics {
+		for _, m := range scope.Metrics {
+			check := func(set attribute.Set) {
+				for _, kv := range set.ToSlice() {
+					if kv.Key == "session_id" || kv.Key == "user_id" {
+						t.Errorf("metric %q contains forbidden label %q", m.Name, kv.Key)
+					}
+				}
+			}
+			switch data := m.Data.(type) {
+			case metricdata.Sum[int64]:
+				for _, dp := range data.DataPoints {
+					check(dp.Attributes)
+				}
+			case metricdata.Sum[float64]:
+				for _, dp := range data.DataPoints {
+					check(dp.Attributes)
+				}
+			case metricdata.Histogram[int64]:
+				for _, dp := range data.DataPoints {
+					check(dp.Attributes)
+				}
+			case metricdata.Histogram[float64]:
+				for _, dp := range data.DataPoints {
+					check(dp.Attributes)
+				}
+			case metricdata.Gauge[int64]:
+				for _, dp := range data.DataPoints {
+					check(dp.Attributes)
+				}
+			case metricdata.Gauge[float64]:
+				for _, dp := range data.DataPoints {
+					check(dp.Attributes)
+				}
+			}
+		}
+	}
+}
+
+func TestHookRecordsCoreInstrumentsAndBoundedLabels(t *testing.T) {
+	reader := metric.NewManualReader()
+	provider := metric.NewMeterProvider(metric.WithReader(reader))
+	defer func() { _ = provider.Shutdown(context.Background()) }()
+	q := queueStats{depth: 7}
+	h := New(q, func() int64 { return 3 })
+	if err := h.Bind(provider.Meter("stella")); err != nil {
+		t.Fatal(err)
+	}
+	h.OnPostAgentCall(context.Background(), &hooks.PostAgentCallContext{
+		HookMeta: hooks.HookMeta{AgentID: "agent-uuid", UserID: "user", SessionID: "session", Channel: "web"}, Duration: time.Second,
+	})
+	h.OnPostLLMCall(context.Background(), &hooks.PostLLMCallContext{
+		HookMeta: hooks.HookMeta{AgentID: "agent-uuid", UserID: "user", SessionID: "session", Channel: "telegram"},
+		Model:    "model", Provider: "provider", Duration: 2 * time.Second, TimeToFirstToken: time.Second,
+		Usage: ai.Usage{
+			Reported: true, InputTokens: 4, OutputTokens: 5, CacheRead: 6, CacheWrite: 7,
+			CostConfigured: true, Cost: ai.UsageCost{Total: 0.25},
+		}, StopReason: ai.StopReasonStop, Attempts: 2,
+	})
+	h.OnPostToolCall(context.Background(), &hooks.PostToolCallContext{
+		HookMeta: hooks.HookMeta{AgentID: "agent-uuid", UserID: "user", SessionID: "session", Channel: "feishu"},
+		ToolName: "bash", IsError: true, ErrorKind: ai.ToolErrorKindCommandNonzero, Duration: time.Second,
+	})
+	h.OnPostMemoryCall(context.Background(), &hooks.PostMemoryCallContext{HookMeta: hooks.HookMeta{UserID: "user", SessionID: "session"}, Op: hooks.MemoryOpSearch, Duration: time.Second})
+	h.RecordQueueDrop()
+
+	rm := collect(t, reader)
+	names := metricNames(rm)
+	for _, name := range []string{
+		"stella.llm.call.duration", "stella.llm.time_to_first_token", "stella.llm.tokens", "stella.llm.cost",
+		"stella.llm.calls", "stella.llm.attempts", "stella.tool.call.duration", "stella.tool.calls",
+		"stella.agent.turn.duration", "stella.agent.turns", "stella.memory.op.duration",
+		"stella.llm_usage.queue.dropped", "stella.llm_usage.queue.depth", "stella.trace.sessions.active",
+	} {
+		if _, ok := names[name]; !ok {
+			t.Errorf("missing metric %q", name)
+		}
+	}
+	assertNoForbiddenLabels(t, rm)
+}
+
+func TestHookBindIsExplicitAndOnlyOnce(t *testing.T) {
+	h := New(nil, nil)
+	reader := metric.NewManualReader()
+	provider := metric.NewMeterProvider(metric.WithReader(reader))
+	defer func() { _ = provider.Shutdown(context.Background()) }()
+	meter := provider.Meter("stella")
+	if err := h.Bind(meter); err != nil {
+		t.Fatal(err)
+	}
+	if err := h.Bind(meter); err == nil {
+		t.Fatal("second Bind succeeded")
+	}
+	// An unbound hook is deliberately inert, not a panic waiting to happen.
+	New(nil, nil).OnPostMemoryCall(context.Background(), &hooks.PostMemoryCallContext{Duration: time.Second})
+}

--- a/internal/observability/observability.go
+++ b/internal/observability/observability.go
@@ -88,6 +88,13 @@ func Init(ctx context.Context) (*Provider, error) {
 		return &Provider{}, nil
 	}
 
+	// SDK export failures must bypass the OTLP leg. A collector outage must not
+	// create a log -> export -> failure -> log feedback loop.
+	consoleLog := slog.New(NewTraceContextHandler(currentSlogHandler()))
+	otel.SetErrorHandler(otel.ErrorHandlerFunc(func(err error) {
+		consoleLog.Warn("otel SDK error", "component", "otel", "error", err)
+	}))
+
 	res, err := newResource(ctx, cfg)
 	if err != nil {
 		return nil, err
@@ -220,7 +227,8 @@ func newTracerProvider(ctx context.Context, res *resource.Resource) (*sdktrace.T
 		return nil, fmt.Errorf("otel: create span exporter: %w", err)
 	}
 
-	// No WithSampler: Stella uses the SDK default ParentBased(AlwaysSample).
+	// The SDK default is ParentBased(AlwaysSample). Operators can reduce noisy
+	// DB/query spans with OTEL_TRACES_SAMPLER and OTEL_TRACES_SAMPLER_ARG.
 	return sdktrace.NewTracerProvider(
 		sdktrace.WithBatcher(exporter),
 		sdktrace.WithResource(res),

--- a/internal/observability/observability.go
+++ b/internal/observability/observability.go
@@ -17,7 +17,9 @@ import (
 	"log/slog"
 	"os"
 	"strings"
+	"sync"
 	"sync/atomic"
+	"time"
 
 	"go.opentelemetry.io/contrib/bridges/otelslog"
 	"go.opentelemetry.io/contrib/exporters/autoexport"
@@ -34,6 +36,7 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/CherryHQ/stella/internal/cli"
 	"github.com/CherryHQ/stella/internal/diagnostic"
 	"github.com/CherryHQ/stella/internal/version"
 	"github.com/CherryHQ/stella/pkg/otelenv"
@@ -45,6 +48,34 @@ import (
 type Config struct {
 	Enabled     bool   // true when trace export is configured and the SDK is not disabled
 	ServiceName string // OTel service name, defaults to "stella"
+}
+
+type errorRateLimiter struct {
+	mu   sync.Mutex
+	last map[string]time.Time
+}
+
+func (r *errorRateLimiter) allow(signal string, now time.Time) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.last == nil {
+		r.last = make(map[string]time.Time)
+	}
+	if previous := r.last[signal]; now.Sub(previous) < time.Minute {
+		return false
+	}
+	r.last[signal] = now
+	return true
+}
+
+func otelErrorSignal(err error) string {
+	message := strings.ToLower(err.Error())
+	for _, signal := range []string{"logs", "traces", "metrics"} {
+		if strings.Contains(message, "/v1/"+signal) || strings.Contains(message, signal+" exporter") {
+			return signal
+		}
+	}
+	return "otel"
 }
 
 // LoadConfig reads OTel settings from the environment. Whether a signal is
@@ -91,8 +122,13 @@ func Init(ctx context.Context) (*Provider, error) {
 	// SDK export failures must bypass the OTLP leg. A collector outage must not
 	// create a log -> export -> failure -> log feedback loop.
 	consoleLog := slog.New(NewTraceContextHandler(currentSlogHandler()))
+	setConsoleOnlyLogger(consoleLog)
+	rateLimiter := &errorRateLimiter{}
 	otel.SetErrorHandler(otel.ErrorHandlerFunc(func(err error) {
-		consoleLog.Warn("otel SDK error", "component", "otel", "error", err)
+		signal := otelErrorSignal(err)
+		if rateLimiter.allow(signal, time.Now()) {
+			consoleLog.Warn("otel SDK error", "component", "otel", "signal", signal, "error", err)
+		}
 	}))
 
 	res, err := newResource(ctx, cfg)
@@ -142,7 +178,8 @@ func Init(ctx context.Context) (*Provider, error) {
 		p.previousLoggerProvider = otellogglobal.GetLoggerProvider()
 		p.previousSlog = slog.Default()
 		otellogglobal.SetLoggerProvider(p.lp)
-		slog.SetDefault(slog.New(newTeeHandler(currentSlogHandler(), otelslog.NewHandler("stella"))))
+		logHandler := cli.NewMinLevelHandler(cli.ParseLogLevel(os.Getenv("LOG_LEVEL")), otelslog.NewHandler("stella"))
+		slog.SetDefault(slog.New(newTeeHandler(currentSlogHandler(), logHandler)))
 		slog.Info("otel logs enabled",
 			"endpoint", logsEndpoint(),
 			"service", cfg.ServiceName)
@@ -290,6 +327,18 @@ func (e *gracefulExporter) ForceFlush(ctx context.Context) error {
 		return nil
 	}
 	return e.inner.ForceFlush(ctx)
+}
+
+// MetricsEnabled reports whether Init installed a real meter provider.
+func (p *Provider) MetricsEnabled() bool { return p != nil && p.mp != nil }
+
+// ForceFlushLogs makes log-export tests and controlled shutdown paths wait for
+// the current batch without exposing the provider implementation.
+func (p *Provider) ForceFlushLogs(ctx context.Context) error {
+	if p == nil || p.lp == nil {
+		return nil
+	}
+	return p.lp.ForceFlush(ctx)
 }
 
 // Shutdown flushes pending telemetry and stops the providers. It is a no-op

--- a/internal/observability/observability_test.go
+++ b/internal/observability/observability_test.go
@@ -150,6 +150,20 @@ func TestSignalEnabledLogsDisabledViaExporterNone(t *testing.T) {
 	}
 }
 
+func TestOTelErrorRateLimiterIsPerSignal(t *testing.T) {
+	limiter := &errorRateLimiter{}
+	now := time.Unix(0, 0)
+	if !limiter.allow("logs", now) || limiter.allow("logs", now.Add(time.Second)) {
+		t.Fatal("logs warning was not rate-limited")
+	}
+	if !limiter.allow("traces", now.Add(time.Second)) {
+		t.Fatal("traces warning incorrectly shared logs limit")
+	}
+	if !limiter.allow("logs", now.Add(time.Minute)) {
+		t.Fatal("logs warning did not reopen after one minute")
+	}
+}
+
 func TestInitDisabledIsNoOp(t *testing.T) {
 	clearOTelEnv(t)
 	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")

--- a/internal/observability/otlp_controlled_test.go
+++ b/internal/observability/otlp_controlled_test.go
@@ -202,6 +202,16 @@ func (a logsServiceAdapter) Export(ctx context.Context, req *logsv1.ExportLogsSe
 	return a.ExportLogsService(ctx, req)
 }
 
+type recordingLogsReceiver struct {
+	logsv1.UnimplementedLogsServiceServer
+	requests chan *logsv1.ExportLogsServiceRequest
+}
+
+func (r *recordingLogsReceiver) Export(_ context.Context, req *logsv1.ExportLogsServiceRequest) (*logsv1.ExportLogsServiceResponse, error) {
+	r.requests <- req
+	return &logsv1.ExportLogsServiceResponse{}, nil
+}
+
 type failingLogsReceiver struct {
 	logsv1.UnimplementedLogsServiceServer
 	calls atomic.Int32
@@ -210,6 +220,121 @@ type failingLogsReceiver struct {
 func (r *failingLogsReceiver) Export(context.Context, *logsv1.ExportLogsServiceRequest) (*logsv1.ExportLogsServiceResponse, error) {
 	r.calls.Add(1)
 	return nil, status.Error(codes.Internal, "collector unavailable")
+}
+
+func TestInitThenSetupLoggerReachesOTLP(t *testing.T) {
+	clearOTelEnv(t)
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	receiver := &recordingLogsReceiver{requests: make(chan *logsv1.ExportLogsServiceRequest, 1)}
+	server := grpc.NewServer()
+	logsv1.RegisterLogsServiceServer(server, receiver)
+	go func() { _ = server.Serve(listener) }()
+	t.Cleanup(func() { server.Stop(); _ = listener.Close() })
+
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://"+listener.Addr().String())
+	t.Setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc")
+	t.Setenv("OTEL_EXPORTER_OTLP_INSECURE", "true")
+	t.Setenv("OTEL_LOGS_EXPORTER", "otlp")
+	t.Setenv("OTEL_TRACES_EXPORTER", "none")
+	t.Setenv("OTEL_METRICS_EXPORTER", "none")
+	previous := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil)))
+	t.Cleanup(func() { slog.SetDefault(previous) })
+
+	p, err := Init(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = p.Shutdown(context.Background()) }()
+	// This mirrors a logger captured by setup after Init has installed the tee.
+	slog.With("hook", "trace").Info("setup logger reached exporter")
+	flushCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := p.lp.ForceFlush(flushCtx); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case req := <-receiver.requests:
+		found := false
+		for _, resource := range req.ResourceLogs {
+			for _, scope := range resource.ScopeLogs {
+				for _, record := range scope.LogRecords {
+					if record.Body.GetStringValue() == "setup logger reached exporter" {
+						found = true
+					}
+				}
+			}
+		}
+		if !found {
+			t.Fatal("setup logger record missing from OTLP request")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("setup logger record did not reach OTLP")
+	}
+}
+
+func TestOTLPLogLegHonorsConfiguredLevel(t *testing.T) {
+	clearOTelEnv(t)
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	receiver := &recordingLogsReceiver{requests: make(chan *logsv1.ExportLogsServiceRequest, 20)}
+	server := grpc.NewServer()
+	logsv1.RegisterLogsServiceServer(server, receiver)
+	go func() { _ = server.Serve(listener) }()
+	defer func() { server.Stop(); _ = listener.Close() }()
+	previous := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil)))
+	defer slog.SetDefault(previous)
+	for _, level := range []struct {
+		value string
+		want  bool
+	}{{"INFO", false}, {"DEBUG", true}} {
+		t.Run(level.value, func(t *testing.T) {
+			t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://"+listener.Addr().String())
+			t.Setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc")
+			t.Setenv("OTEL_EXPORTER_OTLP_INSECURE", "true")
+			t.Setenv("OTEL_LOGS_EXPORTER", "otlp")
+			t.Setenv("OTEL_TRACES_EXPORTER", "none")
+			t.Setenv("OTEL_METRICS_EXPORTER", "none")
+			t.Setenv("LOG_LEVEL", level.value)
+			p, err := Init(context.Background())
+			if err != nil {
+				t.Fatal(err)
+			}
+			slog.Debug("level floor probe")
+			flushCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+			if err := p.ForceFlushLogs(flushCtx); err != nil {
+				t.Fatal(err)
+			}
+			cancel()
+			found := false
+			for {
+				select {
+				case req := <-receiver.requests:
+					for _, resource := range req.ResourceLogs {
+						for _, scope := range resource.ScopeLogs {
+							for _, record := range scope.LogRecords {
+								if record.Body.GetStringValue() == "level floor probe" {
+									found = true
+								}
+							}
+						}
+					}
+				default:
+					if found != level.want {
+						t.Fatalf("debug exported=%v at LOG_LEVEL=%s", found, level.value)
+					}
+					_ = p.Shutdown(context.Background())
+					return
+				}
+			}
+		})
+	}
 }
 
 func TestOTelExporterErrorsUseConsoleOnlyHandler(t *testing.T) {

--- a/internal/observability/otlp_controlled_test.go
+++ b/internal/observability/otlp_controlled_test.go
@@ -201,3 +201,58 @@ type logsServiceAdapter struct{ *controlledOTLPReceiver }
 func (a logsServiceAdapter) Export(ctx context.Context, req *logsv1.ExportLogsServiceRequest) (*logsv1.ExportLogsServiceResponse, error) {
 	return a.ExportLogsService(ctx, req)
 }
+
+type failingLogsReceiver struct {
+	logsv1.UnimplementedLogsServiceServer
+	calls atomic.Int32
+}
+
+func (r *failingLogsReceiver) Export(context.Context, *logsv1.ExportLogsServiceRequest) (*logsv1.ExportLogsServiceResponse, error) {
+	r.calls.Add(1)
+	return nil, status.Error(codes.Internal, "collector unavailable")
+}
+
+func TestOTelExporterErrorsUseConsoleOnlyHandler(t *testing.T) {
+	clearOTelEnv(t)
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	receiver := &failingLogsReceiver{}
+	server := grpc.NewServer()
+	logsv1.RegisterLogsServiceServer(server, receiver)
+	go func() { _ = server.Serve(listener) }()
+	t.Cleanup(func() { server.Stop(); _ = listener.Close() })
+
+	var console bytes.Buffer
+	previousSlog := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&console, nil)))
+	t.Cleanup(func() { slog.SetDefault(previousSlog) })
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://"+listener.Addr().String())
+	t.Setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc")
+	t.Setenv("OTEL_EXPORTER_OTLP_INSECURE", "true")
+	t.Setenv("OTEL_LOGS_EXPORTER", "otlp")
+	t.Setenv("OTEL_TRACES_EXPORTER", "none")
+	t.Setenv("OTEL_METRICS_EXPORTER", "none")
+
+	p, err := Init(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = p.Shutdown(context.Background()) }()
+	slog.Info("one exported record")
+	flushCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	_ = p.lp.ForceFlush(flushCtx)
+	if receiver.calls.Load() == 0 {
+		t.Fatal("log exporter was not called")
+	}
+	if strings.Count(console.String(), "otel SDK error") == 0 || !strings.Contains(console.String(), "component=otel") {
+		t.Fatalf("missing console-only OTel error: %s", console.String())
+	}
+	before := receiver.calls.Load()
+	_ = p.lp.ForceFlush(flushCtx)
+	if receiver.calls.Load() != before {
+		t.Fatalf("error handler caused another OTLP export: before=%d after=%d", before, receiver.calls.Load())
+	}
+}

--- a/internal/observability/slog.go
+++ b/internal/observability/slog.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"reflect"
+	"sync"
 
 	"go.opentelemetry.io/otel/trace"
 )
@@ -49,6 +50,32 @@ func (h traceContextHandler) WithGroup(name string) slog.Handler {
 
 type teeHandler struct {
 	handlers []slog.Handler
+}
+
+var consoleOnlyLogger struct {
+	sync.RWMutex
+	logger *slog.Logger
+}
+
+func setConsoleOnlyLogger(logger *slog.Logger) {
+	consoleOnlyLogger.Lock()
+	consoleOnlyLogger.logger = logger
+	consoleOnlyLogger.Unlock()
+}
+
+// ConsoleOnlyLogger returns a logger that bypasses the OTLP leg. It is for
+// diagnostic details that may contain raw upstream error text; all routine
+// records must continue through slog.Default().
+func ConsoleOnlyLogger() *slog.Logger {
+	consoleOnlyLogger.RLock()
+	logger := consoleOnlyLogger.logger
+	consoleOnlyLogger.RUnlock()
+	if logger != nil {
+		return logger
+	}
+	logger = slog.New(NewTraceContextHandler(currentSlogHandler()))
+	setConsoleOnlyLogger(logger)
+	return logger
 }
 
 func currentSlogHandler() slog.Handler {

--- a/internal/observability/span_error.go
+++ b/internal/observability/span_error.go
@@ -1,0 +1,20 @@
+package observability
+
+import (
+	"fmt"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// RecordSpanError records only a closed error class on a span. Error messages
+// can contain upstream bodies, commands, URLs, or prompt fragments, so they
+// stay in logs and never become exported span status text or exception events.
+func RecordSpanError(span trace.Span, err error, status string) {
+	if span == nil || err == nil {
+		return
+	}
+	span.SetStatus(codes.Error, status)
+	span.SetAttributes(attribute.String("error.type", fmt.Sprintf("%T", err)))
+}

--- a/internal/observability/tracehook/agent.go
+++ b/internal/observability/tracehook/agent.go
@@ -44,7 +44,8 @@ func (h *Hook) OnPostAgentCall(ctx context.Context, hctx *hooks.PostAgentCallCon
 		"channel", hctx.Channel,
 	}
 	if hctx.Error != nil {
-		attrs = append(attrs, "error", hctx.Error)
+		attrs = append(attrs, "error.type", logErrorClass(hctx.Error), "error.class", "agent_call_failed")
+		logRawError("agent call failed", "agent_call_failed", hctx.Error)
 	}
 	h.log.InfoContext(ctx, "post_agent_call", attrs...)
 
@@ -69,7 +70,7 @@ func (h *Hook) OnPostAgentCall(ctx context.Context, hctx *hooks.PostAgentCallCon
 	if hctx.Error != nil {
 		recordSpanError(st.loopSpan, hctx.Error, "agent call failed")
 	}
-	idle := st.activeOps.Load() == 0 && len(st.llmSpans) == 0 && len(st.toolSpans) == 0 && len(st.turnSpans) == 0
+	idle := st.activeOps.Load() == 0 && len(st.llmSpans) == 0 && len(st.toolSpans) == 0
 	st.mu.Unlock()
 	if idle {
 		delete(h.sessions, key)

--- a/internal/observability/tracehook/agent.go
+++ b/internal/observability/tracehook/agent.go
@@ -20,16 +20,16 @@ func (h *Hook) OnPreAgentCall(ctx context.Context, hctx *hooks.PreAgentCallConte
 
 	if h.otelEnabled() && hctx.SessionID != "" {
 		h.mu.Lock()
-		st := h.getOrCreateSession(ctx, hctx.AgentID, hctx.SessionID)
+		st := h.getOrCreateSession(ctx, hctx.AgentID, hctx.SessionID, hctx.Channel, hctx.BindingID)
 		st.mu.Lock()
 		st.loopSpan.SetAttributes(
-			attribute.String("user_id", hctx.UserID),
-			attribute.String("agent_id", hctx.AgentID),
-			attribute.Int("stella.agent_loop.message_len", hctx.MessageLen),
+			attribute.String("stella.user_id", hctx.UserID),
+			attribute.String("stella.agent_id", hctx.AgentID),
+			attribute.Int("stella.agent.message_len", hctx.MessageLen),
+			attribute.String("stella.chat.channel", hctx.Channel),
+			attribute.String("stella.chat.binding_id", hctx.BindingID),
 		)
-		if hctx.Channel != "" {
-			st.loopSpan.SetAttributes(attribute.String("stella.agent_loop.channel", hctx.Channel))
-		}
+
 		st.mu.Unlock()
 		h.mu.Unlock()
 	}
@@ -41,6 +41,7 @@ func (h *Hook) OnPostAgentCall(ctx context.Context, hctx *hooks.PostAgentCallCon
 		"agent_id", hctx.AgentID,
 		"user_id", hctx.UserID,
 		"duration", hctx.Duration.Round(time.Millisecond),
+		"channel", hctx.Channel,
 	}
 	if hctx.Error != nil {
 		attrs = append(attrs, "error", hctx.Error)
@@ -58,20 +59,24 @@ func (h *Hook) OnPostAgentCall(ctx context.Context, hctx *hooks.PostAgentCallCon
 		h.mu.Unlock()
 		return
 	}
-	delete(h.sessions, key)
-	h.mu.Unlock()
-
 	st.mu.Lock()
-	// Set final attributes before closing the session.
+	// A session may have more than one admitted turn. Do not retire the shared
+	// loop span until this callback is the last active operation.
 	st.loopSpan.SetAttributes(
-		attribute.Float64("stella.agent_loop.duration_s", hctx.Duration.Seconds()),
-		attribute.Int("stella.agent_loop.turn_count", st.turnNum),
+		attribute.Float64("stella.agent.turn.duration_s", hctx.Duration.Seconds()),
+		attribute.Int("stella.agent.turn.count", st.turnNum),
 	)
 	if hctx.Error != nil {
 		recordSpanError(st.loopSpan, hctx.Error, "agent call failed")
 	}
+	idle := st.activeOps.Load() == 0 && len(st.llmSpans) == 0 && len(st.toolSpans) == 0 && len(st.turnSpans) == 0
 	st.mu.Unlock()
-
-	// End all remaining spans (tool, LLM, turn, agent loop).
-	h.endSession(st)
+	if idle {
+		delete(h.sessions, key)
+	}
+	h.mu.Unlock()
+	if idle {
+		// End all remaining spans (tool, LLM, turn, agent loop).
+		h.endSession(st)
+	}
 }

--- a/internal/observability/tracehook/code_mode_test.go
+++ b/internal/observability/tracehook/code_mode_test.go
@@ -7,6 +7,10 @@ import (
 	"strings"
 	"testing"
 
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
 	"github.com/CherryHQ/stella/internal/observability/tracehook"
 	"github.com/CherryHQ/stella/pkg/agent"
 	"github.com/CherryHQ/stella/pkg/ai"
@@ -51,10 +55,114 @@ func TestCodeChildTraceUsesNestedAuditIDAndRedactsIO(t *testing.T) {
 	}
 
 	got := logs.String()
-	if strings.Count(got, `"call_id":"outer:1"`) != 2 || !strings.Contains(got, `"tool":"effect"`) || !strings.Contains(got, `"duration"`) {
+	if strings.Count(got, `"call_id":"outer:1"`) != 2 || strings.Count(got, `"tool":"code"`) != 2 || !strings.Contains(got, `"tool":"effect"`) || !strings.Contains(got, `"duration"`) {
 		t.Fatalf("nested trace records = %s", got)
 	}
-	if strings.Contains(got, "sk-proj-abcdef1234567890") || strings.Count(got, "[REDACTED]") < 2 {
-		t.Fatalf("trace IO was not redacted: %s", got)
+	if strings.Contains(got, "sk-proj-abcdef1234567890") || strings.Contains(got, `"input"`) || strings.Contains(got, `"result"`) {
+		t.Fatalf("trace IO was exported without opt-in: %s", got)
+	}
+}
+
+func TestCodeOuterCallHasNestedTraceAndAudit(t *testing.T) {
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	previous := otel.GetTracerProvider()
+	otel.SetTracerProvider(provider)
+	t.Cleanup(func() {
+		otel.SetTracerProvider(previous)
+		_ = provider.Shutdown(context.Background())
+	})
+	hook := tracehook.New(true, false)
+	defer func() { _ = hook.Close() }()
+	streamCalls := 0
+	var providerTools []string
+	stream := func(_ context.Context, _ ai.Model, request ai.Context, _ ai.StreamOptions) (providers.AssistantEventStream, error) {
+		if streamCalls == 0 {
+			for _, tool := range request.Tools {
+				providerTools = append(providerTools, tool.Name)
+			}
+		}
+		streamCalls++
+		out := providers.NewChannelEventStream(2)
+		go func() {
+			if streamCalls == 1 {
+				out.Emit(ai.EventToolCallDelta{ID: "outer", Name: "code", Arguments: `{"code":"await tools.invoke('one'); return await tools.invoke('two');"}`})
+				out.Emit(ai.EventStop{Reason: ai.StopReasonToolUse})
+			} else {
+				out.Emit(ai.EventStop{Reason: ai.StopReasonStop})
+			}
+			out.Finish(nil)
+		}()
+		return out, nil
+	}
+	runner, err := agent.NewRunner(agent.RunnerConfig{
+		Stream: stream,
+		Tools: agent.ToolSet{
+			"one": func(context.Context, ai.ToolCall) ([]ai.ContentBlock, error) {
+				return []ai.ContentBlock{ai.TextContent{Text: "one"}}, nil
+			},
+			"two": func(context.Context, ai.ToolCall) ([]ai.ContentBlock, error) {
+				return []ai.ContentBlock{ai.TextContent{Text: "two"}}, nil
+			},
+		},
+		ToolDefinitions: []ai.ToolDefinition{{Name: "one"}, {Name: "two"}},
+	}, agent.WithHooks(hooks.NewHookSet([]hooks.HookPlugin{hook}), hooks.HookMeta{AgentID: "agent", SessionID: "session"}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runner.RunWithActiveStart(context.Background(), []ai.Message{ai.UserMessage{Content: "go"}}, 0, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	spans := tracetest.SpanStubsFromReadOnlySpans(recorder.Ended())
+	turns := make([]tracetest.SpanStub, 0, 2)
+	var outer, chat tracetest.SpanStub
+	children := make([]tracetest.SpanStub, 0, 2)
+	for _, span := range spans {
+		switch span.Name {
+		case "agent.turn":
+			turns = append(turns, span)
+		case "gen_ai.chat":
+			chat = span
+		case "gen_ai.execute_tool":
+			name := ""
+			for _, kv := range span.Attributes {
+				if string(kv.Key) == "gen_ai.tool.name" {
+					name = kv.Value.AsString()
+				}
+			}
+			if name == "code" {
+				outer = span
+			} else {
+				children = append(children, span)
+			}
+		}
+	}
+	if len(turns) == 0 || !outer.SpanContext.IsValid() || !chat.SpanContext.IsValid() || len(children) != 2 {
+		t.Fatalf("spans = %#v", spans)
+	}
+	var seenProviderTools []string
+	for _, kv := range chat.Attributes {
+		if string(kv.Key) == "gen_ai.request.tool_names" {
+			seenProviderTools = kv.Value.AsStringSlice()
+		}
+	}
+	if strings.Join(seenProviderTools, ",") != strings.Join(providerTools, ",") {
+		t.Fatalf("provider tools in span=%v, provider received=%v", seenProviderTools, providerTools)
+	}
+	var turn tracetest.SpanStub
+	for _, candidate := range turns {
+		if outer.Parent.SpanID() == candidate.SpanContext.SpanID() {
+			turn = candidate
+			break
+		}
+	}
+	if !turn.SpanContext.IsValid() {
+		t.Fatalf("code parent=%v did not match a turn: %#v", outer.Parent.SpanID(), turns)
+	}
+	for _, child := range children {
+		if child.Parent.SpanID() != outer.SpanContext.SpanID() {
+			t.Fatalf("child parent=%v want code=%v", child.Parent.SpanID(), outer.SpanContext.SpanID())
+		}
 	}
 }

--- a/internal/observability/tracehook/code_mode_test.go
+++ b/internal/observability/tracehook/code_mode_test.go
@@ -96,6 +96,7 @@ func TestCodeOuterCallHasNestedTraceAndAudit(t *testing.T) {
 		return out, nil
 	}
 	runner, err := agent.NewRunner(agent.RunnerConfig{
+		Model:  ai.Model{Name: "model"},
 		Stream: stream,
 		Tools: agent.ToolSet{
 			"one": func(context.Context, ai.ToolCall) ([]ai.ContentBlock, error) {
@@ -113,6 +114,7 @@ func TestCodeOuterCallHasNestedTraceAndAudit(t *testing.T) {
 	if _, err := runner.RunWithActiveStart(context.Background(), []ai.Message{ai.UserMessage{Content: "go"}}, 0, nil); err != nil {
 		t.Fatal(err)
 	}
+	hook.OnPostAgentCall(context.Background(), &hooks.PostAgentCallContext{HookMeta: hooks.HookMeta{AgentID: "agent", SessionID: "session"}})
 
 	spans := tracetest.SpanStubsFromReadOnlySpans(recorder.Ended())
 	turns := make([]tracetest.SpanStub, 0, 2)
@@ -122,9 +124,9 @@ func TestCodeOuterCallHasNestedTraceAndAudit(t *testing.T) {
 		switch span.Name {
 		case "agent.turn":
 			turns = append(turns, span)
-		case "gen_ai.chat":
+		case "chat model":
 			chat = span
-		case "gen_ai.execute_tool":
+		case "execute_tool one", "execute_tool two", "execute_tool code", "execute_tool bash":
 			name := ""
 			for _, kv := range span.Attributes {
 				if string(kv.Key) == "gen_ai.tool.name" {
@@ -143,7 +145,7 @@ func TestCodeOuterCallHasNestedTraceAndAudit(t *testing.T) {
 	}
 	var seenProviderTools []string
 	for _, kv := range chat.Attributes {
-		if string(kv.Key) == "gen_ai.request.tool_names" {
+		if string(kv.Key) == "stella.llm.provider_tool_names" {
 			seenProviderTools = kv.Value.AsStringSlice()
 		}
 	}
@@ -160,9 +162,27 @@ func TestCodeOuterCallHasNestedTraceAndAudit(t *testing.T) {
 	if !turn.SpanContext.IsValid() {
 		t.Fatalf("code parent=%v did not match a turn: %#v", outer.Parent.SpanID(), turns)
 	}
+	var childCount, childErrorCount int64
+	var failureClass string
+	for _, kv := range outer.Attributes {
+		switch string(kv.Key) {
+		case "stella.tool.child_count":
+			childCount = kv.Value.AsInt64()
+		case "stella.tool.child_error_count":
+			childErrorCount = kv.Value.AsInt64()
+		case "stella.tool.failure_class":
+			failureClass = kv.Value.AsString()
+		}
+	}
+	if childCount != 2 || childErrorCount != 0 || failureClass != "" {
+		t.Fatalf("code audit attributes count=%d errors=%d class=%q", childCount, childErrorCount, failureClass)
+	}
 	for _, child := range children {
 		if child.Parent.SpanID() != outer.SpanContext.SpanID() {
 			t.Fatalf("child parent=%v want code=%v", child.Parent.SpanID(), outer.SpanContext.SpanID())
+		}
+		if turn.EndTime.Before(child.EndTime) {
+			t.Fatalf("turn ended before child: turn=%s child=%s", turn.EndTime, child.EndTime)
 		}
 	}
 }

--- a/internal/observability/tracehook/errors.go
+++ b/internal/observability/tracehook/errors.go
@@ -1,0 +1,21 @@
+package tracehook
+
+import (
+	"fmt"
+
+	"github.com/CherryHQ/stella/internal/observability"
+)
+
+func logErrorClass(err error) string {
+	if err == nil {
+		return "none"
+	}
+	return fmt.Sprintf("%T", err)
+}
+
+func logRawError(component, class string, err error) {
+	if err == nil {
+		return
+	}
+	observability.ConsoleOnlyLogger().Warn(component, "error.type", logErrorClass(err), "error.class", class, "error", err)
+}

--- a/internal/observability/tracehook/hook.go
+++ b/internal/observability/tracehook/hook.go
@@ -39,6 +39,11 @@ func sessionKey(agentID, sessionID string) string {
 	return agentID + ":" + sessionID
 }
 
+type toolSpanState struct {
+	span   trace.Span
+	turnID string
+}
+
 // sessionTrace tracks the active span hierarchy for one chat session. Multiple
 // turn/LLM pairs may be live briefly, so per-call spans are keyed by CallID.
 type sessionTrace struct {
@@ -47,16 +52,20 @@ type sessionTrace struct {
 	loopSpan trace.Span
 	loopCtx  context.Context
 
-	turnCtx context.Context
-	turnNum int
+	turnCtx       context.Context
+	turnNum       int
+	currentTurnID string
 
 	// Calls are keyed independently so concurrent turns in one session cannot
 	// end each other's spans.
-	turnSpans map[string]trace.Span
-	llmSpans  map[string]trace.Span
+	turnSpans       map[string]trace.Span
+	turnContexts    map[string]context.Context
+	turnActiveTools map[string]int
+	llmSpans        map[string]trace.Span
+	spanToTurn      map[trace.SpanID]string
 
 	// Tool call spans keyed by ToolCallID.
-	toolSpans map[string]trace.Span
+	toolSpans map[string]toolSpanState
 
 	activeOps  atomic.Int32
 	lastActive time.Time
@@ -167,12 +176,15 @@ func (h *Hook) getOrCreateSession(parentCtx context.Context, agentID, sessionID,
 	startOptions = append(startOptions, loopOptions...)
 	ctx, loopSpan := h.tracer().Start(context.WithoutCancel(parentCtx), "agent.loop", startOptions...)
 	st = &sessionTrace{
-		loopSpan:   loopSpan,
-		loopCtx:    ctx,
-		toolSpans:  make(map[string]trace.Span),
-		turnSpans:  make(map[string]trace.Span),
-		llmSpans:   make(map[string]trace.Span),
-		lastActive: time.Now(),
+		loopSpan:        loopSpan,
+		loopCtx:         ctx,
+		toolSpans:       make(map[string]toolSpanState),
+		turnSpans:       make(map[string]trace.Span),
+		turnContexts:    make(map[string]context.Context),
+		turnActiveTools: make(map[string]int),
+		llmSpans:        make(map[string]trace.Span),
+		spanToTurn:      make(map[trace.SpanID]string),
+		lastActive:      time.Now(),
 	}
 	h.sessions[key] = st
 	return st
@@ -189,7 +201,10 @@ func (h *Hook) endSession(st *sessionTrace) {
 	loopSpan := st.loopSpan
 	st.llmSpans = make(map[string]trace.Span)
 	st.turnSpans = make(map[string]trace.Span)
-	st.toolSpans = make(map[string]trace.Span)
+	st.turnContexts = make(map[string]context.Context)
+	st.turnActiveTools = make(map[string]int)
+	st.spanToTurn = make(map[trace.SpanID]string)
+	st.toolSpans = make(map[string]toolSpanState)
 	st.loopSpan = nil
 	st.mu.Unlock()
 
@@ -199,12 +214,20 @@ func (h *Hook) endSession(st *sessionTrace) {
 	for _, span := range turnSpans {
 		span.End()
 	}
-	for _, span := range toolSpans {
-		span.End()
+	for _, state := range toolSpans {
+		state.span.End()
 	}
 	if loopSpan != nil {
 		loopSpan.End()
 	}
+}
+
+func claimTurnLocked(st *sessionTrace, turnID string) trace.Span {
+	span := st.turnSpans[turnID]
+	delete(st.turnSpans, turnID)
+	delete(st.turnContexts, turnID)
+	delete(st.turnActiveTools, turnID)
+	return span
 }
 
 // reaper periodically cleans up idle sessions. It exits on ctx cancellation

--- a/internal/observability/tracehook/hook.go
+++ b/internal/observability/tracehook/hook.go
@@ -146,22 +146,26 @@ func (h *Hook) Close() error {
 // (HTTP/channel entry) — so the whole agent trace nests under that span instead
 // of starting a disconnected root. Cancellation is stripped because the loop
 // outlives the HTTP request: a cancelled parent must not tear down the
-// session's long-lived spans, and span linkage only needs the parent's span
-// context, not its deadline. Caller must hold h.mu.
+// agent-call spans, and span linkage only needs the parent's span context,
+// not its deadline. Caller must hold h.mu.
 func (h *Hook) getOrCreateSession(parentCtx context.Context, agentID, sessionID, channel, bindingID string) *sessionTrace {
 	key := sessionKey(agentID, sessionID)
 	st, ok := h.sessions[key]
 	if ok {
 		return st
 	}
-	ctx, loopSpan := h.tracer().Start(context.WithoutCancel(parentCtx), "agent.loop",
-		trace.WithAttributes(
-			attribute.String("gen_ai.conversation.id", sessionID),
-			attribute.String("stella.agent_id", agentID),
-			attribute.String("stella.chat.channel", channel),
-			attribute.String("stella.chat.binding_id", bindingID),
-		),
-	)
+	loopOptions := []trace.SpanStartOption{}
+	if parent := trace.SpanContextFromContext(parentCtx); parent.IsValid() {
+		loopOptions = append(loopOptions, trace.WithLinks(trace.Link{SpanContext: parent}))
+	}
+	startOptions := []trace.SpanStartOption{trace.WithAttributes(
+		attribute.String("gen_ai.conversation.id", sessionID),
+		attribute.String("stella.agent_id", agentID),
+		attribute.String("stella.chat.channel", channel),
+		attribute.String("stella.chat.binding_id", bindingID),
+	)}
+	startOptions = append(startOptions, loopOptions...)
+	ctx, loopSpan := h.tracer().Start(context.WithoutCancel(parentCtx), "agent.loop", startOptions...)
 	st = &sessionTrace{
 		loopSpan:   loopSpan,
 		loopCtx:    ctx,

--- a/internal/observability/tracehook/hook.go
+++ b/internal/observability/tracehook/hook.go
@@ -39,19 +39,21 @@ func sessionKey(agentID, sessionID string) string {
 	return agentID + ":" + sessionID
 }
 
-// sessionTrace tracks the active span hierarchy for one chat session.
+// sessionTrace tracks the active span hierarchy for one chat session. Multiple
+// turn/LLM pairs may be live briefly, so per-call spans are keyed by CallID.
 type sessionTrace struct {
 	mu sync.Mutex // protects all fields below
 
 	loopSpan trace.Span
 	loopCtx  context.Context
 
-	turnSpan trace.Span
-	turnCtx  context.Context
-	turnNum  int
+	turnCtx context.Context
+	turnNum int
 
-	// LLM call span (one at a time per session).
-	llmSpan trace.Span
+	// Calls are keyed independently so concurrent turns in one session cannot
+	// end each other's spans.
+	turnSpans map[string]trace.Span
+	llmSpans  map[string]trace.Span
 
 	// Tool call spans keyed by ToolCallID.
 	toolSpans map[string]trace.Span
@@ -107,6 +109,16 @@ func (*Hook) Priority() int { return 0 } // runs first
 
 func (h *Hook) otelEnabled() bool { return h.enabled }
 
+// ActiveSessions reports the number of session traces currently retained.
+func (h *Hook) ActiveSessions() int64 {
+	if h == nil {
+		return 0
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return int64(len(h.sessions))
+}
+
 // tracer resolves the global tracer lazily so spans always use whatever
 // provider the observability package installed at startup, never a stale one
 // captured at hook construction.
@@ -136,7 +148,7 @@ func (h *Hook) Close() error {
 // outlives the HTTP request: a cancelled parent must not tear down the
 // session's long-lived spans, and span linkage only needs the parent's span
 // context, not its deadline. Caller must hold h.mu.
-func (h *Hook) getOrCreateSession(parentCtx context.Context, agentID, sessionID string) *sessionTrace {
+func (h *Hook) getOrCreateSession(parentCtx context.Context, agentID, sessionID, channel, bindingID string) *sessionTrace {
 	key := sessionKey(agentID, sessionID)
 	st, ok := h.sessions[key]
 	if ok {
@@ -145,13 +157,17 @@ func (h *Hook) getOrCreateSession(parentCtx context.Context, agentID, sessionID 
 	ctx, loopSpan := h.tracer().Start(context.WithoutCancel(parentCtx), "agent.loop",
 		trace.WithAttributes(
 			attribute.String("gen_ai.conversation.id", sessionID),
-			attribute.String("agent_id", agentID),
+			attribute.String("stella.agent_id", agentID),
+			attribute.String("stella.chat.channel", channel),
+			attribute.String("stella.chat.binding_id", bindingID),
 		),
 	)
 	st = &sessionTrace{
 		loopSpan:   loopSpan,
 		loopCtx:    ctx,
 		toolSpans:  make(map[string]trace.Span),
+		turnSpans:  make(map[string]trace.Span),
+		llmSpans:   make(map[string]trace.Span),
 		lastActive: time.Now(),
 	}
 	h.sessions[key] = st
@@ -163,24 +179,24 @@ func (h *Hook) getOrCreateSession(parentCtx context.Context, agentID, sessionID 
 // in-flight callback can never double-End the same span.
 func (h *Hook) endSession(st *sessionTrace) {
 	st.mu.Lock()
-	llmSpan := st.llmSpan
+	llmSpans := st.llmSpans
+	turnSpans := st.turnSpans
 	toolSpans := st.toolSpans
-	turnSpan := st.turnSpan
 	loopSpan := st.loopSpan
-	st.llmSpan = nil
+	st.llmSpans = make(map[string]trace.Span)
+	st.turnSpans = make(map[string]trace.Span)
 	st.toolSpans = make(map[string]trace.Span)
-	st.turnSpan = nil
 	st.loopSpan = nil
 	st.mu.Unlock()
 
-	if llmSpan != nil {
-		llmSpan.End()
+	for _, span := range llmSpans {
+		span.End()
+	}
+	for _, span := range turnSpans {
+		span.End()
 	}
 	for _, span := range toolSpans {
 		span.End()
-	}
-	if turnSpan != nil {
-		turnSpan.End()
 	}
 	if loopSpan != nil {
 		loopSpan.End()

--- a/internal/observability/tracehook/llm.go
+++ b/internal/observability/tracehook/llm.go
@@ -67,8 +67,11 @@ func (h *Hook) OnPreLLMCall(ctx context.Context, hctx *hooks.PreLLMCallContext) 
 		var llmSpan trace.Span
 		llmCtx, llmSpan = h.tracer().Start(turnCtx, fmt.Sprintf("chat %s", hctx.Model), trace.WithAttributes(attrs...))
 		st.turnCtx = turnCtx
+		st.currentTurnID = callID
+		st.turnContexts[callID] = turnCtx
 		st.turnSpans[callID] = turnSpan
 		st.llmSpans[callID] = llmSpan
+		st.spanToTurn[llmSpan.SpanContext().SpanID()] = callID
 		st.activeOps.Add(1)
 		st.lastActive = time.Now()
 		st.mu.Unlock()
@@ -193,9 +196,17 @@ func (h *Hook) OnPostLLMCall(ctx context.Context, hctx *hooks.PostLLMCallContext
 	}
 	span.End()
 	st.mu.Lock()
+	delete(st.spanToTurn, span.SpanContext().SpanID())
 	st.activeOps.Add(-1)
 	st.lastActive = time.Now()
+	var turnSpan trace.Span
+	if hctx.ToolCallCount == 0 && st.turnActiveTools[callID] == 0 {
+		turnSpan = claimTurnLocked(st, callID)
+	}
 	st.mu.Unlock()
+	if turnSpan != nil {
+		turnSpan.End()
+	}
 }
 
 // serverHost reduces a configured base URL to its host. The rest of the URL is

--- a/internal/observability/tracehook/llm.go
+++ b/internal/observability/tracehook/llm.go
@@ -65,7 +65,7 @@ func (h *Hook) OnPreLLMCall(ctx context.Context, hctx *hooks.PreLLMCallContext) 
 			attrs = append(attrs, attribute.Float64("gen_ai.request.temperature", *hctx.Temperature))
 		}
 		var llmSpan trace.Span
-		llmCtx, llmSpan = h.tracer().Start(turnCtx, "gen_ai.chat", trace.WithAttributes(attrs...))
+		llmCtx, llmSpan = h.tracer().Start(turnCtx, fmt.Sprintf("chat %s", hctx.Model), trace.WithAttributes(attrs...))
 		st.turnCtx = turnCtx
 		st.turnSpans[callID] = turnSpan
 		st.llmSpans[callID] = llmSpan
@@ -113,7 +113,8 @@ func (h *Hook) OnPostLLMCall(ctx context.Context, hctx *hooks.PostLLMCallContext
 		attrs = append(attrs, "cost_usd", hctx.Usage.Cost.Total)
 	}
 	if hctx.Error != nil {
-		attrs = append(attrs, "error", hctx.Error)
+		attrs = append(attrs, "error.type", logErrorClass(hctx.Error), "error.class", "llm_call_failed")
+		logRawError("llm call failed", "llm_call_failed", hctx.Error)
 	}
 	h.log.InfoContext(ctx, "post_llm_call", attrs...)
 
@@ -137,8 +138,6 @@ func (h *Hook) OnPostLLMCall(ctx context.Context, hctx *hooks.PostLLMCallContext
 	}
 	span := st.llmSpans[callID]
 	delete(st.llmSpans, callID)
-	turnSpan := st.turnSpans[callID]
-	delete(st.turnSpans, callID)
 	if span != nil {
 		st.lastActive = time.Now()
 	}
@@ -159,8 +158,8 @@ func (h *Hook) OnPostLLMCall(ctx context.Context, hctx *hooks.PostLLMCallContext
 		attribute.Int("gen_ai.usage.input_tokens", hctx.Usage.InputTokens),
 		attribute.Int("gen_ai.usage.output_tokens", hctx.Usage.OutputTokens),
 		attribute.Int("stella.llm.total_tokens", hctx.Usage.TotalTokens),
-		attribute.StringSlice("gen_ai.request.tool_names", hctx.ProviderToolNames),
-		attribute.Int("gen_ai.request.tool_count", len(hctx.ProviderToolNames)),
+		attribute.StringSlice("stella.llm.provider_tool_names", hctx.ProviderToolNames),
+		attribute.Int("stella.llm.provider_tool_count", len(hctx.ProviderToolNames)),
 		attribute.Int("stella.code.catalog_size", hctx.CodeCatalogSize),
 		attribute.String("stella.chat.channel", hctx.Channel),
 		attribute.String("stella.chat.binding_id", hctx.BindingID),
@@ -193,9 +192,6 @@ func (h *Hook) OnPostLLMCall(ctx context.Context, hctx *hooks.PostLLMCallContext
 		recordSpanError(span, hctx.Error, "model call failed")
 	}
 	span.End()
-	if turnSpan != nil {
-		turnSpan.End()
-	}
 	st.mu.Lock()
 	st.activeOps.Add(-1)
 	st.lastActive = time.Now()

--- a/internal/observability/tracehook/llm.go
+++ b/internal/observability/tracehook/llm.go
@@ -17,40 +17,26 @@ func (h *Hook) OnPreLLMCall(ctx context.Context, hctx *hooks.PreLLMCallContext) 
 	for i, t := range hctx.ToolDefinitions {
 		tools[i] = t.Name
 	}
-	h.log.InfoContext(ctx, "pre_llm_call",
-		"model", hctx.Model,
-		"messages", hctx.MessageCount,
-		"tools", len(tools),
-		"tool_names", tools,
-		"system_len", len(hctx.System),
-		"session_id", hctx.SessionID,
-		"agent_id", hctx.AgentID,
-		"user_id", hctx.UserID,
-	)
 
+	llmCtx := ctx
 	if h.otelEnabled() && hctx.SessionID != "" {
 		h.mu.Lock()
-		st := h.getOrCreateSession(ctx, hctx.AgentID, hctx.SessionID)
+		st := h.getOrCreateSession(ctx, hctx.AgentID, hctx.SessionID, hctx.Channel, hctx.BindingID)
 		h.mu.Unlock()
 
 		st.mu.Lock()
-		// End a prior LLM span that never saw its OnPostLLMCall (e.g. a dropped
-		// or interleaved call) so it can't leak or pin activeOps forever.
-		if st.llmSpan != nil {
-			st.llmSpan.End()
-			st.llmSpan = nil
-			st.activeOps.Add(-1)
-		}
-		if st.turnSpan != nil {
-			st.turnSpan.End()
-		}
 		st.turnNum++
-		st.turnCtx, st.turnSpan = h.tracer().Start(st.loopCtx,
-			fmt.Sprintf("turn %d", st.turnNum),
+		callID := hctx.CallID
+		if callID == "" {
+			callID = fmt.Sprintf("turn-%d", st.turnNum)
+		}
+		turnCtx, turnSpan := h.tracer().Start(st.loopCtx, "agent.turn",
 			trace.WithAttributes(
 				attribute.Int("stella.turn.number", st.turnNum),
-				attribute.String("user_id", hctx.UserID),
-				attribute.String("agent_id", hctx.AgentID),
+				attribute.String("stella.user_id", hctx.UserID),
+				attribute.String("stella.agent_id", hctx.AgentID),
+				attribute.String("stella.chat.channel", hctx.Channel),
+				attribute.String("stella.chat.binding_id", hctx.BindingID),
 			),
 		)
 
@@ -59,12 +45,12 @@ func (h *Hook) OnPreLLMCall(ctx context.Context, hctx *hooks.PreLLMCallContext) 
 			attribute.String("gen_ai.system", hctx.API),
 			attribute.String("gen_ai.request.model", hctx.Model),
 			attribute.String("gen_ai.conversation.id", hctx.SessionID),
-			attribute.String("user_id", hctx.UserID),
-			attribute.String("agent_id", hctx.AgentID),
-			attribute.Int("gen_ai.request.message_count", hctx.MessageCount),
-			attribute.Int("gen_ai.request.tool_count", len(tools)),
-			attribute.StringSlice("gen_ai.request.tool_names", tools),
-			attribute.Int("gen_ai.request.system_prompt_len", len(hctx.System)),
+			attribute.String("stella.user_id", hctx.UserID),
+			attribute.String("stella.agent_id", hctx.AgentID),
+			attribute.String("stella.chat.channel", hctx.Channel),
+			attribute.String("stella.chat.binding_id", hctx.BindingID),
+			attribute.Int("stella.llm.message_count", hctx.MessageCount),
+			attribute.Int("stella.llm.system_prompt_length", len(hctx.System)),
 		}
 		if hctx.Provider != "" {
 			attrs = append(attrs, attribute.String("gen_ai.provider.name", hctx.Provider))
@@ -78,19 +64,30 @@ func (h *Hook) OnPreLLMCall(ctx context.Context, hctx *hooks.PreLLMCallContext) 
 		if hctx.Temperature != nil {
 			attrs = append(attrs, attribute.Float64("gen_ai.request.temperature", *hctx.Temperature))
 		}
-
-		var llmCtx context.Context
-		llmCtx, st.llmSpan = h.tracer().Start(st.turnCtx, "gen_ai.chat",
-			trace.WithAttributes(attrs...),
-		)
+		var llmSpan trace.Span
+		llmCtx, llmSpan = h.tracer().Start(turnCtx, "gen_ai.chat", trace.WithAttributes(attrs...))
+		st.turnCtx = turnCtx
+		st.turnSpans[callID] = turnSpan
+		st.llmSpans[callID] = llmSpan
 		st.activeOps.Add(1)
 		st.lastActive = time.Now()
 		st.mu.Unlock()
-
-		// Return the span context so the provider HTTP call becomes a child of gen_ai.chat.
-		return hooks.PreLLMCallResult{Context: llmCtx}, nil
 	}
 
+	h.log.InfoContext(llmCtx, "pre_llm_call",
+		"model", hctx.Model,
+		"messages", hctx.MessageCount,
+		"effective_tool_count", len(tools),
+		"effective_tools", tools,
+		"system_len", len(hctx.System),
+		"session_id", hctx.SessionID,
+		"agent_id", hctx.AgentID,
+		"user_id", hctx.UserID,
+		"channel", hctx.Channel,
+	)
+	if h.otelEnabled() && hctx.SessionID != "" {
+		return hooks.PreLLMCallResult{Context: llmCtx}, nil
+	}
 	return hooks.PreLLMCallResult{}, nil
 }
 
@@ -110,6 +107,7 @@ func (h *Hook) OnPostLLMCall(ctx context.Context, hctx *hooks.PostLLMCallContext
 		"session_id", hctx.SessionID,
 		"agent_id", hctx.AgentID,
 		"user_id", hctx.UserID,
+		"channel", hctx.Channel,
 	}
 	if hctx.Usage.Cost.Total > 0 {
 		attrs = append(attrs, "cost_usd", hctx.Usage.Cost.Total)
@@ -130,12 +128,17 @@ func (h *Hook) OnPostLLMCall(ctx context.Context, hctx *hooks.PostLLMCallContext
 		return
 	}
 
-	// Claim the span under the lock (nil it out) before ending it, so a
-	// concurrent endSession (reaper/Close) can never snapshot the same span and
-	// End it twice. Mirrors OnPostToolCall, which deletes from the map first.
 	st.mu.Lock()
-	span := st.llmSpan
-	st.llmSpan = nil
+	callID := hctx.CallID
+	if callID == "" && len(st.llmSpans) == 1 {
+		for id := range st.llmSpans {
+			callID = id
+		}
+	}
+	span := st.llmSpans[callID]
+	delete(st.llmSpans, callID)
+	turnSpan := st.turnSpans[callID]
+	delete(st.turnSpans, callID)
 	if span != nil {
 		st.lastActive = time.Now()
 	}
@@ -144,7 +147,6 @@ func (h *Hook) OnPostLLMCall(ctx context.Context, hctx *hooks.PostLLMCallContext
 		return
 	}
 
-	// Resolve provider name: prefer explicit Provider, fall back to API key.
 	providerName := hctx.Provider
 	if providerName == "" {
 		providerName = hctx.API
@@ -156,7 +158,12 @@ func (h *Hook) OnPostLLMCall(ctx context.Context, hctx *hooks.PostLLMCallContext
 		attribute.StringSlice("gen_ai.response.finish_reasons", []string{string(hctx.StopReason)}),
 		attribute.Int("gen_ai.usage.input_tokens", hctx.Usage.InputTokens),
 		attribute.Int("gen_ai.usage.output_tokens", hctx.Usage.OutputTokens),
-		attribute.Int("gen_ai.usage.total_tokens", hctx.Usage.TotalTokens),
+		attribute.Int("stella.llm.total_tokens", hctx.Usage.TotalTokens),
+		attribute.StringSlice("gen_ai.request.tool_names", hctx.ProviderToolNames),
+		attribute.Int("gen_ai.request.tool_count", len(hctx.ProviderToolNames)),
+		attribute.Int("stella.code.catalog_size", hctx.CodeCatalogSize),
+		attribute.String("stella.chat.channel", hctx.Channel),
+		attribute.String("stella.chat.binding_id", hctx.BindingID),
 	)
 	if host := serverHost(hctx.BaseURL); host != "" {
 		span.SetAttributes(attribute.String("server.address", host))
@@ -168,31 +175,31 @@ func (h *Hook) OnPostLLMCall(ctx context.Context, hctx *hooks.PostLLMCallContext
 		span.SetAttributes(attribute.Int("gen_ai.usage.cache_creation.input_tokens", hctx.Usage.CacheWrite))
 	}
 	span.SetAttributes(
-		attribute.String("gen_ai.server.duration", hctx.Duration.Round(time.Millisecond).String()),
-		attribute.Float64("gen_ai.server.duration_s", hctx.Duration.Seconds()),
+		attribute.Float64("stella.llm.call.duration_s", hctx.Duration.Seconds()),
 	)
 	if hctx.TimeToFirstToken > 0 {
-		span.SetAttributes(
-			attribute.String("gen_ai.server.time_to_first_token", hctx.TimeToFirstToken.Round(time.Millisecond).String()),
-			attribute.Float64("gen_ai.server.time_to_first_token_s", hctx.TimeToFirstToken.Seconds()),
-		)
+		span.SetAttributes(attribute.Float64("stella.llm.time_to_first_token_s", hctx.TimeToFirstToken.Seconds()))
 	}
 	if hctx.Usage.Cost.Total > 0 {
-		span.SetAttributes(attribute.Float64("gen_ai.usage.cost_usd", hctx.Usage.Cost.Total))
+		span.SetAttributes(attribute.Float64("stella.llm.cost_usd", hctx.Usage.Cost.Total))
 	}
 	if hctx.Attempts > 0 {
-		// Retries happen inside the provider SDK, below every span this hook
-		// owns; the count is the only place they surface on the parent.
 		span.SetAttributes(
-			attribute.Int("gen_ai.request.attempts", hctx.Attempts),
-			attribute.Int("gen_ai.request.retry_count", hctx.Attempts-1),
+			attribute.Int("stella.llm.attempts", hctx.Attempts),
+			attribute.Int("stella.llm.retry_count", hctx.Attempts-1),
 		)
 	}
 	if hctx.Error != nil {
 		recordSpanError(span, hctx.Error, "model call failed")
 	}
 	span.End()
+	if turnSpan != nil {
+		turnSpan.End()
+	}
+	st.mu.Lock()
 	st.activeOps.Add(-1)
+	st.lastActive = time.Now()
+	st.mu.Unlock()
 }
 
 // serverHost reduces a configured base URL to its host. The rest of the URL is
@@ -204,7 +211,6 @@ func serverHost(baseURL string) string {
 	}
 	u, err := url.Parse(baseURL)
 	if err != nil || u.Host == "" {
-		// Unparseable, so nothing here can be trusted to be host-only.
 		return ""
 	}
 	return u.Host

--- a/internal/observability/tracehook/log_safety_test.go
+++ b/internal/observability/tracehook/log_safety_test.go
@@ -1,0 +1,87 @@
+package tracehook
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	v1 "go.opentelemetry.io/proto/otlp/collector/logs/v1"
+	"google.golang.org/grpc"
+
+	"github.com/CherryHQ/stella/internal/observability"
+	"github.com/CherryHQ/stella/pkg/hooks"
+)
+
+type logCaptureServer struct {
+	v1.UnimplementedLogsServiceServer
+	requests chan *v1.ExportLogsServiceRequest
+}
+
+func (s *logCaptureServer) Export(_ context.Context, req *v1.ExportLogsServiceRequest) (*v1.ExportLogsServiceResponse, error) {
+	s.requests <- req
+	return &v1.ExportLogsServiceResponse{}, nil
+}
+
+func TestHookErrorTextStaysOffOTLPLogLeg(t *testing.T) {
+	for _, key := range []string{
+		"OTEL_SDK_DISABLED", "OTEL_EXPORTER_OTLP_ENDPOINT", "OTEL_EXPORTER_OTLP_PROTOCOL",
+		"OTEL_EXPORTER_OTLP_INSECURE", "OTEL_TRACES_EXPORTER", "OTEL_LOGS_EXPORTER", "OTEL_METRICS_EXPORTER",
+	} {
+		t.Setenv(key, "")
+	}
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	receiver := &logCaptureServer{requests: make(chan *v1.ExportLogsServiceRequest, 1)}
+	server := grpc.NewServer()
+	v1.RegisterLogsServiceServer(server, receiver)
+	go func() { _ = server.Serve(listener) }()
+	t.Cleanup(func() { server.Stop(); _ = listener.Close() })
+	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://"+listener.Addr().String())
+	t.Setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc")
+	t.Setenv("OTEL_EXPORTER_OTLP_INSECURE", "true")
+	t.Setenv("OTEL_LOGS_EXPORTER", "otlp")
+	t.Setenv("OTEL_TRACES_EXPORTER", "none")
+	t.Setenv("OTEL_METRICS_EXPORTER", "none")
+	previous := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&discardWriter{}, nil)))
+	t.Cleanup(func() { slog.SetDefault(previous) })
+
+	provider, err := observability.Init(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = provider.Shutdown(context.Background()) }()
+	hook := New(false, false)
+	secret := "provider-body-secret-should-not-leave"
+	hook.OnPostLLMCall(context.Background(), &hooks.PostLLMCallContext{
+		Model: "model", Error: errors.New(secret), Duration: time.Millisecond,
+	})
+	flushCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := provider.ForceFlushLogs(flushCtx); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case req := <-receiver.requests:
+		wire := fmt.Sprint(req)
+		if wire == "" {
+			t.Fatal("empty OTLP log request")
+		}
+		if strings.Contains(wire, secret) {
+			t.Fatalf("OTLP log contains raw error text: %s", wire)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("hook log did not reach OTLP")
+	}
+}
+
+type discardWriter struct{}
+
+func (*discardWriter) Write(p []byte) (int, error) { return len(p), nil }

--- a/internal/observability/tracehook/memory.go
+++ b/internal/observability/tracehook/memory.go
@@ -65,13 +65,17 @@ func (h *Hook) OnPreMemoryCall(ctx context.Context, hctx *hooks.PreMemoryCallCon
 		return hooks.PreMemoryCallResult{}, nil
 	}
 
+	spanAttrs := []attribute.KeyValue{
+		attribute.String("stella.memory.op", string(hctx.Op)),
+		attribute.String("stella.chat.channel", hctx.Channel),
+		attribute.String("stella.chat.binding_id", hctx.BindingID),
+		attribute.String("stella.agent_id", hctx.AgentID),
+	}
+	if hctx.SessionID != "" {
+		spanAttrs = append(spanAttrs, attribute.String("stella.memory.session_id", hctx.SessionID))
+	}
 	spanCtx, span := h.tracer().Start(parentCtx, fmt.Sprintf("memory.%s", hctx.Op),
-		trace.WithAttributes(
-			attribute.String("stella.memory.op", string(hctx.Op)),
-			attribute.String("stella.memory.session_id", hctx.SessionID),
-			attribute.String("user_id", hctx.UserID),
-			attribute.String("agent_id", hctx.AgentID),
-		),
+		trace.WithAttributes(spanAttrs...),
 	)
 	if st != nil {
 		st.activeOps.Add(1)
@@ -87,9 +91,12 @@ func (h *Hook) OnPostMemoryCall(ctx context.Context, hctx *hooks.PostMemoryCallC
 	attrs := []any{
 		"op", string(hctx.Op),
 		"duration", hctx.Duration.Round(time.Millisecond),
-		"session_id", hctx.SessionID,
 		"agent_id", hctx.AgentID,
 		"user_id", hctx.UserID,
+		"channel", hctx.Channel,
+	}
+	if hctx.SessionID != "" {
+		attrs = append(attrs, "session_id", hctx.SessionID)
 	}
 	if hctx.MessageCount > 0 {
 		attrs = append(attrs, "message_count", hctx.MessageCount)
@@ -112,7 +119,11 @@ func (h *Hook) OnPostMemoryCall(ctx context.Context, hctx *hooks.PostMemoryCallC
 	if hctx.Detail != "" && h.log.Enabled(context.Background(), levelTrace) {
 		attrs = append(attrs, "detail", hctx.Detail)
 	}
-	h.log.InfoContext(ctx, "post_memory_call", attrs...)
+	if hctx.SessionID == "" && hctx.Error == nil && hctx.Op != hooks.MemoryOpCompact {
+		h.log.DebugContext(ctx, "post_memory_call", attrs...)
+	} else {
+		h.log.InfoContext(ctx, "post_memory_call", attrs...)
+	}
 
 	if !h.otelEnabled() {
 		return
@@ -135,8 +146,8 @@ func (h *Hook) OnPostMemoryCall(ctx context.Context, hctx *hooks.PostMemoryCallC
 	if st == nil {
 		return
 	}
-	st.activeOps.Add(-1)
 	st.mu.Lock()
+	st.activeOps.Add(-1)
 	st.lastActive = time.Now()
 	st.mu.Unlock()
 }

--- a/internal/observability/tracehook/memory.go
+++ b/internal/observability/tracehook/memory.go
@@ -52,7 +52,7 @@ func (h *Hook) OnPreMemoryCall(ctx context.Context, hctx *hooks.PreMemoryCallCon
 		h.mu.Lock()
 		st = h.sessions[key]
 		h.mu.Unlock()
-		if st != nil {
+		if st != nil && !trace.SpanContextFromContext(parentCtx).IsValid() {
 			st.mu.Lock()
 			parentCtx = st.loopCtx
 			if st.turnCtx != nil {
@@ -78,8 +78,8 @@ func (h *Hook) OnPreMemoryCall(ctx context.Context, hctx *hooks.PreMemoryCallCon
 		trace.WithAttributes(spanAttrs...),
 	)
 	if st != nil {
-		st.activeOps.Add(1)
 		st.mu.Lock()
+		st.activeOps.Add(1)
 		st.lastActive = time.Now()
 		st.mu.Unlock()
 	}
@@ -114,7 +114,8 @@ func (h *Hook) OnPostMemoryCall(ctx context.Context, hctx *hooks.PostMemoryCallC
 		attrs = append(attrs, "result_count", hctx.ResultCount)
 	}
 	if hctx.Error != nil {
-		attrs = append(attrs, "error", hctx.Error)
+		attrs = append(attrs, "error.type", logErrorClass(hctx.Error), "error.class", "memory_operation_failed")
+		logRawError("memory operation failed", "memory_operation_failed", hctx.Error)
 	}
 	if hctx.Detail != "" && h.log.Enabled(context.Background(), levelTrace) {
 		attrs = append(attrs, "detail", hctx.Detail)

--- a/internal/observability/tracehook/tool.go
+++ b/internal/observability/tracehook/tool.go
@@ -10,6 +10,7 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/CherryHQ/stella/internal/observability"
 	"github.com/CherryHQ/stella/pkg/ai"
 	"github.com/CherryHQ/stella/pkg/hooks"
 )
@@ -31,20 +32,23 @@ func redactSecrets(s string) string {
 // us, and a fixed description. The message itself stays in the logs, which
 // are not exported by default.
 func recordSpanError(span trace.Span, err error, what string) {
-	span.SetStatus(codes.Error, what)
-	span.SetAttributes(attribute.String("error.type", fmt.Sprintf("%T", err)))
+	observability.RecordSpanError(span, err, what)
 }
 
 func (h *Hook) OnPreToolCall(ctx context.Context, hctx *hooks.PreToolCallContext) (hooks.PreToolCallResult, error) {
 	input := redactSecrets(summarizeArgs(hctx.ToolName, hctx.Arguments))
-	h.log.InfoContext(ctx, "pre_tool_call",
+	logAttrs := []any{
 		"tool", hctx.ToolName,
 		"call_id", hctx.ToolCallID,
-		"input", input,
 		"session_id", hctx.SessionID,
 		"agent_id", hctx.AgentID,
 		"user_id", hctx.UserID,
-	)
+		"channel", hctx.Channel,
+	}
+	if h.recordIO {
+		logAttrs = append(logAttrs, "input", input)
+	}
+	h.log.InfoContext(ctx, "pre_tool_call", logAttrs...)
 
 	if h.otelEnabled() && hctx.SessionID != "" {
 		key := sessionKey(hctx.AgentID, hctx.SessionID)
@@ -54,6 +58,9 @@ func (h *Hook) OnPreToolCall(ctx context.Context, hctx *hooks.PreToolCallContext
 		if st != nil {
 			st.mu.Lock()
 			parentCtx := st.turnCtx
+			if hooks.HasToolParent(ctx) && trace.SpanContextFromContext(ctx).IsValid() {
+				parentCtx = ctx
+			}
 			if parentCtx == nil {
 				parentCtx = st.loopCtx
 			}
@@ -63,23 +70,25 @@ func (h *Hook) OnPreToolCall(ctx context.Context, hctx *hooks.PreToolCallContext
 				attribute.String("gen_ai.operation.name", "execute_tool"),
 				attribute.String("gen_ai.tool.name", hctx.ToolName),
 				attribute.String("gen_ai.tool.call.id", hctx.ToolCallID),
-				attribute.String("tool", hctx.ToolName),
-				attribute.String("action", action),
-				attribute.String("user_id", hctx.UserID),
-				attribute.String("agent_id", hctx.AgentID),
-				attribute.Int("gen_ai.tool.argument_count", len(hctx.Arguments)),
+				attribute.String("stella.tool.name", hctx.ToolName),
+				attribute.String("stella.tool.action", action),
+				attribute.String("stella.user_id", hctx.UserID),
+				attribute.String("stella.agent_id", hctx.AgentID),
+				attribute.String("stella.chat.channel", hctx.Channel),
+				attribute.String("stella.chat.binding_id", hctx.BindingID),
+				attribute.Int("stella.tool.argument_count", len(hctx.Arguments)),
 			}
 			if h.recordIO {
-				attrs = append(attrs, attribute.String("gen_ai.tool.input", input))
+				attrs = append(attrs, attribute.String("stella.tool.input", input))
 			}
 			toolCtx, span := h.tracer().Start(parentCtx, "gen_ai.execute_tool",
 				trace.WithAttributes(attrs...),
 			)
 
 			st.toolSpans[hctx.ToolCallID] = span
+			st.activeOps.Add(1)
 			st.lastActive = time.Now()
 			st.mu.Unlock()
-			st.activeOps.Add(1)
 
 			// Hand the span-enriched context back so the tool's DB/memory work
 			// nests under this tool span instead of becoming root spans.
@@ -101,10 +110,20 @@ func (h *Hook) OnPostToolCall(ctx context.Context, hctx *hooks.PostToolCallConte
 		"is_error", hctx.IsError,
 		"duration", hctx.Duration,
 		"result_len", len(hctx.Result),
-		"result", resultSnippet,
 		"session_id", hctx.SessionID,
 		"agent_id", hctx.AgentID,
 		"user_id", hctx.UserID,
+		"channel", hctx.Channel,
+	}
+	if h.recordIO {
+		logAttrs = append(logAttrs, "result", resultSnippet)
+	}
+	if hctx.ChildToolCallAudit.Count > 0 {
+		logAttrs = append(logAttrs,
+			"child_count", hctx.ChildToolCallAudit.Count,
+			"child_error_count", hctx.ChildToolCallAudit.ErrorCount,
+			"failure_class", hctx.ChildToolCallAudit.FailureClass,
+		)
 	}
 	if hctx.ErrorKind != "" {
 		logAttrs = append(logAttrs, "error_kind", string(hctx.ErrorKind))
@@ -137,14 +156,17 @@ func (h *Hook) OnPostToolCall(ctx context.Context, hctx *hooks.PostToolCallConte
 	}
 
 	span.SetAttributes(
-		attribute.Int("gen_ai.tool.result_len", len(hctx.Result)),
-		attribute.Float64("gen_ai.tool.duration_s", hctx.Duration.Seconds()),
+		attribute.Int("stella.tool.result_len", len(hctx.Result)),
+		attribute.Float64("stella.tool.call.duration_s", hctx.Duration.Seconds()),
+		attribute.Int("stella.tool.child_count", hctx.ChildToolCallAudit.Count),
+		attribute.Int("stella.tool.child_error_count", hctx.ChildToolCallAudit.ErrorCount),
+		attribute.String("stella.tool.failure_class", hctx.ChildToolCallAudit.FailureClass),
 	)
 	if h.recordIO {
-		span.SetAttributes(attribute.String("gen_ai.tool.result", resultSnippet))
+		span.SetAttributes(attribute.String("stella.tool.result", resultSnippet))
 	}
 	if hctx.ExitCode != nil {
-		span.SetAttributes(attribute.Int("gen_ai.tool.exit_code", *hctx.ExitCode))
+		span.SetAttributes(attribute.Int("stella.tool.exit_code", *hctx.ExitCode))
 	}
 	if hctx.IsError {
 		kind := hctx.ErrorKind
@@ -153,7 +175,7 @@ func (h *Hook) OnPostToolCall(ctx context.Context, hctx *hooks.PostToolCallConte
 			kind = ai.ToolErrorKindTool
 		}
 		span.SetAttributes(
-			attribute.String("gen_ai.tool.error_kind", string(kind)),
+			attribute.String("stella.tool.error_kind", string(kind)),
 			attribute.String("error.type", string(kind)),
 		)
 		// Only a broken tool is a failed operation. A command that ran and
@@ -165,8 +187,8 @@ func (h *Hook) OnPostToolCall(ctx context.Context, hctx *hooks.PostToolCallConte
 	}
 	span.End()
 
-	st.activeOps.Add(-1)
 	st.mu.Lock()
+	st.activeOps.Add(-1)
 	st.lastActive = time.Now()
 	st.mu.Unlock()
 }

--- a/internal/observability/tracehook/tool.go
+++ b/internal/observability/tracehook/tool.go
@@ -57,9 +57,16 @@ func (h *Hook) OnPreToolCall(ctx context.Context, hctx *hooks.PreToolCallContext
 		h.mu.Unlock()
 		if st != nil {
 			st.mu.Lock()
-			parentCtx := st.turnCtx
+			turnID := st.spanToTurn[trace.SpanContextFromContext(ctx).SpanID()]
+			if turnID == "" {
+				turnID = st.currentTurnID
+			}
+			parentCtx := st.turnContexts[turnID]
 			if hooks.HasToolParent(ctx) && trace.SpanContextFromContext(ctx).IsValid() {
 				parentCtx = ctx
+			}
+			if parentCtx == nil {
+				parentCtx = st.turnCtx
 			}
 			if parentCtx == nil {
 				parentCtx = st.loopCtx
@@ -85,7 +92,11 @@ func (h *Hook) OnPreToolCall(ctx context.Context, hctx *hooks.PreToolCallContext
 				trace.WithAttributes(attrs...),
 			)
 
-			st.toolSpans[hctx.ToolCallID] = span
+			st.toolSpans[hctx.ToolCallID] = toolSpanState{span: span, turnID: turnID}
+			st.spanToTurn[span.SpanContext().SpanID()] = turnID
+			if turnID != "" {
+				st.turnActiveTools[turnID]++
+			}
 			st.activeOps.Add(1)
 			st.lastActive = time.Now()
 			st.mu.Unlock()
@@ -145,15 +156,17 @@ func (h *Hook) OnPostToolCall(ctx context.Context, hctx *hooks.PostToolCallConte
 	}
 
 	st.mu.Lock()
-	span, ok := st.toolSpans[hctx.ToolCallID]
+	state, ok := st.toolSpans[hctx.ToolCallID]
 	if ok {
 		delete(st.toolSpans, hctx.ToolCallID)
 	}
 	st.mu.Unlock()
 
-	if !ok || span == nil {
+	if !ok || state.span == nil {
 		return
 	}
+	span := state.span
+	turnID := state.turnID
 
 	span.SetAttributes(
 		attribute.Int("stella.tool.result_len", len(hctx.Result)),
@@ -190,7 +203,22 @@ func (h *Hook) OnPostToolCall(ctx context.Context, hctx *hooks.PostToolCallConte
 	st.mu.Lock()
 	st.activeOps.Add(-1)
 	st.lastActive = time.Now()
+	var turnSpan trace.Span
+	if turnID != "" {
+		if st.turnActiveTools[turnID] > 1 {
+			st.turnActiveTools[turnID]--
+		} else {
+			delete(st.turnActiveTools, turnID)
+		}
+		if st.turnActiveTools[turnID] == 0 && st.llmSpans[turnID] == nil {
+			turnSpan = claimTurnLocked(st, turnID)
+		}
+	}
+	st.lastActive = time.Now()
 	st.mu.Unlock()
+	if turnSpan != nil {
+		turnSpan.End()
+	}
 }
 
 func summarizeArgs(tool string, args map[string]any) string {

--- a/internal/observability/tracehook/tool.go
+++ b/internal/observability/tracehook/tool.go
@@ -81,7 +81,7 @@ func (h *Hook) OnPreToolCall(ctx context.Context, hctx *hooks.PreToolCallContext
 			if h.recordIO {
 				attrs = append(attrs, attribute.String("stella.tool.input", input))
 			}
-			toolCtx, span := h.tracer().Start(parentCtx, "gen_ai.execute_tool",
+			toolCtx, span := h.tracer().Start(parentCtx, fmt.Sprintf("execute_tool %s", hctx.ToolName),
 				trace.WithAttributes(attrs...),
 			)
 

--- a/internal/observability/tracehook/tracehook_enabled_test.go
+++ b/internal/observability/tracehook/tracehook_enabled_test.go
@@ -1,8 +1,10 @@
 package tracehook
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log/slog"
 	"strings"
 	"testing"
 	"time"
@@ -13,6 +15,7 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 
+	"github.com/CherryHQ/stella/internal/observability"
 	"github.com/CherryHQ/stella/pkg/ai"
 	"github.com/CherryHQ/stella/pkg/hooks"
 )
@@ -114,14 +117,14 @@ func TestHook_EnabledSpanHierarchy(t *testing.T) {
 
 	// Each span must be ended exactly once: a leaked (never-ended) span is absent
 	// from Ended() entirely, and a double-End would inflate the count.
-	for _, want := range []string{"agent.loop", "turn 1", "gen_ai.chat", "gen_ai.execute_tool", "memory.search"} {
+	for _, want := range []string{"agent.loop", "agent.turn", "gen_ai.chat", "gen_ai.execute_tool", "memory.search"} {
 		if names[want] != 1 {
 			t.Errorf("span %q ended %d times, want 1", want, names[want])
 		}
 	}
 
 	loop, _ := spanByName(spans, "agent.loop")
-	turn, _ := spanByName(spans, "turn 1")
+	turn, _ := spanByName(spans, "agent.turn")
 	chat, _ := spanByName(spans, "gen_ai.chat")
 	tool, _ := spanByName(spans, "gen_ai.execute_tool")
 	mem, _ := spanByName(spans, "memory.search")
@@ -129,7 +132,7 @@ func TestHook_EnabledSpanHierarchy(t *testing.T) {
 	if loop.Parent.IsValid() {
 		t.Errorf("agent.loop should be a root span, got parent %v", loop.Parent.SpanID())
 	}
-	assertChildOf(t, "turn 1", turn, loop)
+	assertChildOf(t, "agent.turn", turn, loop)
 	assertChildOf(t, "gen_ai.chat", chat, turn)
 	assertChildOf(t, "gen_ai.execute_tool", tool, turn)
 	assertChildOf(t, "memory.search", mem, turn)
@@ -150,13 +153,13 @@ func TestHook_ToolIORecording(t *testing.T) {
 		if !ok {
 			t.Fatal("missing gen_ai.execute_tool span")
 		}
-		if _, ok := attrValue(tool, "gen_ai.tool.input"); ok {
+		if _, ok := attrValue(tool, "stella.tool.input"); ok {
 			t.Error("gen_ai.tool.input recorded without opt-in")
 		}
-		if _, ok := attrValue(tool, "gen_ai.tool.result"); ok {
+		if _, ok := attrValue(tool, "stella.tool.result"); ok {
 			t.Error("gen_ai.tool.result recorded without opt-in")
 		}
-		if v, ok := attrValue(tool, "gen_ai.tool.argument_count"); !ok || v.AsInt64() != 1 {
+		if v, ok := attrValue(tool, "stella.tool.argument_count"); !ok || v.AsInt64() != 1 {
 			t.Errorf("argument_count = %d (ok=%v), want 1", v.AsInt64(), ok)
 		}
 	})
@@ -169,14 +172,14 @@ func TestHook_ToolIORecording(t *testing.T) {
 		if !ok {
 			t.Fatal("missing gen_ai.execute_tool span")
 		}
-		in, ok := attrValue(tool, "gen_ai.tool.input")
+		in, ok := attrValue(tool, "stella.tool.input")
 		if !ok {
 			t.Fatal("gen_ai.tool.input not recorded under opt-in")
 		}
 		if in.AsString() != "echo hi" {
 			t.Errorf("tool.input = %q, want %q", in.AsString(), "echo hi")
 		}
-		if _, ok := attrValue(tool, "gen_ai.tool.result"); !ok {
+		if _, ok := attrValue(tool, "stella.tool.result"); !ok {
 			t.Error("gen_ai.tool.result not recorded under opt-in")
 		}
 	})
@@ -332,13 +335,13 @@ func TestHook_ToolSpanErrorKind(t *testing.T) {
 			if !ok {
 				t.Fatal("missing gen_ai.execute_tool span")
 			}
-			if v, ok := attrValue(span, "gen_ai.tool.error_kind"); !ok || v.AsString() != tc.wantKind {
+			if v, ok := attrValue(span, "stella.tool.error_kind"); !ok || v.AsString() != tc.wantKind {
 				t.Errorf("error_kind = %q (ok=%v), want %q", v.AsString(), ok, tc.wantKind)
 			}
 			if v, ok := attrValue(span, "error.type"); !ok || v.AsString() != tc.wantKind {
 				t.Errorf("error.type = %q (ok=%v), want %q", v.AsString(), ok, tc.wantKind)
 			}
-			v, ok := attrValue(span, "gen_ai.tool.exit_code")
+			v, ok := attrValue(span, "stella.tool.exit_code")
 			switch {
 			case tc.wantExit < 0 && ok:
 				t.Errorf("exit_code = %d, want no attribute", v.AsInt64())
@@ -360,7 +363,7 @@ func TestHook_ToolSpanSuccessCarriesNoErrorKind(t *testing.T) {
 	if !ok {
 		t.Fatal("missing gen_ai.execute_tool span")
 	}
-	if v, ok := attrValue(span, "gen_ai.tool.error_kind"); ok {
+	if v, ok := attrValue(span, "stella.tool.error_kind"); ok {
 		t.Errorf("successful tool span carries error_kind %q", v.AsString())
 	}
 	if span.Status.Code == codes.Error {
@@ -383,18 +386,51 @@ func TestHook_ChatSpanRecordsProviderAttempts(t *testing.T) {
 	if !ok {
 		t.Fatal("missing gen_ai.chat span")
 	}
-	if v, ok := attrValue(chat, "gen_ai.request.attempts"); !ok || v.AsInt64() != 3 {
+	if v, ok := attrValue(chat, "stella.llm.attempts"); !ok || v.AsInt64() != 3 {
 		t.Errorf("attempts = %d (ok=%v), want 3", v.AsInt64(), ok)
 	}
-	if v, ok := attrValue(chat, "gen_ai.request.retry_count"); !ok || v.AsInt64() != 2 {
+	if v, ok := attrValue(chat, "stella.llm.retry_count"); !ok || v.AsInt64() != 2 {
 		t.Errorf("retry_count = %d (ok=%v), want 2", v.AsInt64(), ok)
 	}
-	if v, ok := attrValue(chat, "gen_ai.server.time_to_first_token_s"); !ok || v.AsFloat64() != 0.25 {
+	if v, ok := attrValue(chat, "stella.llm.time_to_first_token_s"); !ok || v.AsFloat64() != 0.25 {
 		t.Errorf("ttft = %v (ok=%v), want 0.25", v.AsFloat64(), ok)
 	}
 }
 
 // A stream that never went over HTTP counted nothing; absent is not "one try".
+func TestHook_ProviderToolSurfaceAndLogCorrelation(t *testing.T) {
+	var logs bytes.Buffer
+	previous := slog.Default()
+	slog.SetDefault(slog.New(observability.NewTraceContextHandler(slog.NewJSONHandler(&logs, nil))))
+	t.Cleanup(func() { slog.SetDefault(previous) })
+	h, sr := newRecordingHook(t, false)
+	meta := hooks.HookMeta{SessionID: "surface", AgentID: "agent-uuid", UserID: "user", Channel: "web", BindingID: "binding"}
+	pre := hooks.PreLLMCallContext{HookMeta: meta, CallID: "call", Model: "model", API: "provider", ToolDefinitions: []ai.ToolDefinition{{Name: "hidden"}}}
+	if _, err := h.OnPreLLMCall(context.Background(), &pre); err != nil {
+		t.Fatal(err)
+	}
+	h.OnPostLLMCall(context.Background(), &hooks.PostLLMCallContext{
+		HookMeta: meta, CallID: "call", Model: "model", API: "provider",
+		ProviderToolNames: []string{"bash", "code"}, CodeCatalogSize: 12,
+	})
+	chat, ok := spanByName(endedStubs(sr), "gen_ai.chat")
+	if !ok {
+		t.Fatal("missing gen_ai.chat span")
+	}
+	if got, ok := attrValue(chat, "gen_ai.request.tool_names"); !ok || got.AsStringSlice() == nil || strings.Join(got.AsStringSlice(), ",") != "bash,code" {
+		t.Fatalf("provider tool names = %v (ok=%v)", got, ok)
+	}
+	if got, ok := attrValue(chat, "gen_ai.request.tool_count"); !ok || got.AsInt64() != 2 {
+		t.Fatalf("provider tool count = %v (ok=%v)", got, ok)
+	}
+	if got, ok := attrValue(chat, "stella.code.catalog_size"); !ok || got.AsInt64() != 12 {
+		t.Fatalf("catalog size = %v (ok=%v)", got, ok)
+	}
+	if !strings.Contains(logs.String(), `"trace_id"`) || !strings.Contains(logs.String(), `"span_id"`) {
+		t.Fatalf("pre_llm_call was not correlated: %s", logs.String())
+	}
+}
+
 func TestHook_ChatSpanOmitsUncountedAttempts(t *testing.T) {
 	h, sr := newRecordingHook(t, false)
 	meta := hooks.HookMeta{SessionID: "sess-noattempts", AgentID: "agent-1", UserID: "u1"}
@@ -402,7 +438,7 @@ func TestHook_ChatSpanOmitsUncountedAttempts(t *testing.T) {
 	h.OnPostLLMCall(context.Background(), &hooks.PostLLMCallContext{HookMeta: meta, Model: "claude-3"})
 
 	chat, _ := spanByName(endedStubs(sr), "gen_ai.chat")
-	if _, ok := attrValue(chat, "gen_ai.request.attempts"); ok {
+	if _, ok := attrValue(chat, "stella.llm.attempts"); ok {
 		t.Error("attempts recorded when nothing counted them")
 	}
 }

--- a/internal/observability/tracehook/tracehook_enabled_test.go
+++ b/internal/observability/tracehook/tracehook_enabled_test.go
@@ -144,6 +144,59 @@ func TestHook_EnabledSpanHierarchy(t *testing.T) {
 	}
 }
 
+func TestHookTurnsEndAtTheirWorkBoundary(t *testing.T) {
+	h, sr := newRecordingHook(t, false)
+	meta := hooks.HookMeta{SessionID: "turn-boundary", AgentID: "agent-1", UserID: "u1"}
+	first, err := h.OnPreLLMCall(context.Background(), &hooks.PreLLMCallContext{HookMeta: meta, CallID: "turn-1", Model: "claude-3"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	h.OnPostLLMCall(first.Context, &hooks.PostLLMCallContext{HookMeta: meta, CallID: "turn-1", Model: "claude-3", ToolCallCount: 1})
+	tool, err := h.OnPreToolCall(first.Context, &hooks.PreToolCallContext{HookMeta: meta, ToolName: "bash", ToolCallID: "tool-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	h.OnPostToolCall(tool.Context, &hooks.PostToolCallContext{HookMeta: meta, ToolName: "bash", ToolCallID: "tool-1", Duration: time.Millisecond})
+	_, err = h.OnPreLLMCall(context.Background(), &hooks.PreLLMCallContext{HookMeta: meta, CallID: "turn-2", Model: "claude-3"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	h.OnPostLLMCall(context.Background(), &hooks.PostLLMCallContext{HookMeta: meta, CallID: "turn-2", Model: "claude-3", ToolCallCount: 0})
+	h.OnPostAgentCall(context.Background(), &hooks.PostAgentCallContext{HookMeta: meta})
+
+	var turns []tracetest.SpanStub
+	var toolSpan tracetest.SpanStub
+	for _, span := range endedStubs(sr) {
+		if span.Name == "agent.turn" {
+			turns = append(turns, span)
+		}
+		if span.Name == "execute_tool bash" {
+			toolSpan = span
+		}
+	}
+	if len(turns) != 2 || !toolSpan.SpanContext.IsValid() {
+		t.Fatalf("turns=%#v tool=%#v", turns, toolSpan)
+	}
+	var firstTurn, secondTurn tracetest.SpanStub
+	for _, turn := range turns {
+		if value, ok := attrValue(turn, "stella.turn.number"); ok && value.AsInt64() == 1 {
+			firstTurn = turn
+		}
+		if value, ok := attrValue(turn, "stella.turn.number"); ok && value.AsInt64() == 2 {
+			secondTurn = turn
+		}
+	}
+	if !firstTurn.SpanContext.IsValid() || !secondTurn.SpanContext.IsValid() {
+		t.Fatalf("turns missing numbers: %#v", turns)
+	}
+	if firstTurn.EndTime.After(secondTurn.StartTime) {
+		t.Fatalf("turn 1 ended after turn 2 started: %s > %s", firstTurn.EndTime, secondTurn.StartTime)
+	}
+	if firstTurn.EndTime.Before(toolSpan.EndTime) {
+		t.Fatalf("turn 1 ended before its tool: %s < %s", firstTurn.EndTime, toolSpan.EndTime)
+	}
+}
+
 func TestHook_MemoryFromToolNestsUnderTool(t *testing.T) {
 	h, sr := newRecordingHook(t, false)
 	meta := hooks.HookMeta{SessionID: "memory-parent", AgentID: "agent-1", UserID: "u1"}

--- a/internal/observability/tracehook/tracehook_enabled_test.go
+++ b/internal/observability/tracehook/tracehook_enabled_test.go
@@ -117,7 +117,7 @@ func TestHook_EnabledSpanHierarchy(t *testing.T) {
 
 	// Each span must be ended exactly once: a leaked (never-ended) span is absent
 	// from Ended() entirely, and a double-End would inflate the count.
-	for _, want := range []string{"agent.loop", "agent.turn", "gen_ai.chat", "gen_ai.execute_tool", "memory.search"} {
+	for _, want := range []string{"agent.loop", "agent.turn", "chat claude-3", "execute_tool bash", "memory.search"} {
 		if names[want] != 1 {
 			t.Errorf("span %q ended %d times, want 1", want, names[want])
 		}
@@ -125,16 +125,16 @@ func TestHook_EnabledSpanHierarchy(t *testing.T) {
 
 	loop, _ := spanByName(spans, "agent.loop")
 	turn, _ := spanByName(spans, "agent.turn")
-	chat, _ := spanByName(spans, "gen_ai.chat")
-	tool, _ := spanByName(spans, "gen_ai.execute_tool")
+	chat, _ := spanByName(spans, "chat claude-3")
+	tool, _ := spanByName(spans, "execute_tool bash")
 	mem, _ := spanByName(spans, "memory.search")
 
 	if loop.Parent.IsValid() {
 		t.Errorf("agent.loop should be a root span, got parent %v", loop.Parent.SpanID())
 	}
 	assertChildOf(t, "agent.turn", turn, loop)
-	assertChildOf(t, "gen_ai.chat", chat, turn)
-	assertChildOf(t, "gen_ai.execute_tool", tool, turn)
+	assertChildOf(t, "chat claude-3", chat, turn)
+	assertChildOf(t, "execute_tool bash", tool, turn)
 	assertChildOf(t, "memory.search", mem, turn)
 	if got, ok := attrValue(chat, "gen_ai.usage.cache_read.input_tokens"); !ok || got.AsInt64() != 7 {
 		t.Errorf("cache read tokens = %d (ok=%v), want 7", got.AsInt64(), ok)
@@ -144,14 +144,41 @@ func TestHook_EnabledSpanHierarchy(t *testing.T) {
 	}
 }
 
+func TestHook_MemoryFromToolNestsUnderTool(t *testing.T) {
+	h, sr := newRecordingHook(t, false)
+	meta := hooks.HookMeta{SessionID: "memory-parent", AgentID: "agent-1", UserID: "u1"}
+	_, _ = h.OnPreLLMCall(context.Background(), &hooks.PreLLMCallContext{HookMeta: meta, Model: "claude-3"})
+	toolResult, err := h.OnPreToolCall(context.Background(), &hooks.PreToolCallContext{HookMeta: meta, ToolName: "bash", ToolCallID: "call-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	memoryResult, err := h.OnPreMemoryCall(toolResult.Context, &hooks.PreMemoryCallContext{HookMeta: meta, Op: hooks.MemoryOpSearch, SessionID: meta.SessionID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	h.OnPostMemoryCall(memoryResult.Context, &hooks.PostMemoryCallContext{HookMeta: meta, Op: hooks.MemoryOpSearch, SessionID: meta.SessionID, Duration: time.Millisecond})
+	h.OnPostToolCall(toolResult.Context, &hooks.PostToolCallContext{HookMeta: meta, ToolName: "bash", ToolCallID: "call-1", Duration: time.Millisecond})
+	h.OnPostAgentCall(context.Background(), &hooks.PostAgentCallContext{HookMeta: meta})
+	spans := endedStubs(sr)
+	tool, ok := spanByName(spans, "execute_tool bash")
+	if !ok {
+		t.Fatal("missing tool span")
+	}
+	memory, ok := spanByName(spans, "memory.search")
+	if !ok {
+		t.Fatal("missing memory span")
+	}
+	assertChildOf(t, "memory.search", memory, tool)
+}
+
 func TestHook_ToolIORecording(t *testing.T) {
 	t.Run("default omits tool input/result", func(t *testing.T) {
 		h, sr := newRecordingHook(t, false)
 		driveSession(h, "sess-off", nil)
 
-		tool, ok := spanByName(endedStubs(sr), "gen_ai.execute_tool")
+		tool, ok := spanByName(endedStubs(sr), "execute_tool bash")
 		if !ok {
-			t.Fatal("missing gen_ai.execute_tool span")
+			t.Fatal("missing execute_tool {tool} span")
 		}
 		if _, ok := attrValue(tool, "stella.tool.input"); ok {
 			t.Error("gen_ai.tool.input recorded without opt-in")
@@ -168,9 +195,9 @@ func TestHook_ToolIORecording(t *testing.T) {
 		h, sr := newRecordingHook(t, true)
 		driveSession(h, "sess-on", nil)
 
-		tool, ok := spanByName(endedStubs(sr), "gen_ai.execute_tool")
+		tool, ok := spanByName(endedStubs(sr), "execute_tool bash")
 		if !ok {
-			t.Fatal("missing gen_ai.execute_tool span")
+			t.Fatal("missing execute_tool {tool} span")
 		}
 		in, ok := attrValue(tool, "stella.tool.input")
 		if !ok {
@@ -200,12 +227,12 @@ func TestHook_DuplicatePostLLMCall(t *testing.T) {
 
 	count := 0
 	for _, s := range endedStubs(sr) {
-		if s.Name == "gen_ai.chat" {
+		if s.Name == "chat m" {
 			count++
 		}
 	}
 	if count != 1 {
-		t.Errorf("gen_ai.chat ended %d times, want 1", count)
+		t.Errorf("chat {model} ended %d times, want 1", count)
 	}
 }
 
@@ -218,9 +245,9 @@ func TestHook_SpanErrorCarriesNoProviderText(t *testing.T) {
 	raw := "provider failed: POST https://gw.example/v1?auth_blob=" + secret + " -> 401 unauthorized"
 	driveSession(h, "sess-err", errors.New(raw))
 
-	chat, ok := spanByName(endedStubs(sr), "gen_ai.chat")
+	chat, ok := spanByName(endedStubs(sr), "chat claude-3")
 	if !ok {
-		t.Fatal("missing gen_ai.chat span")
+		t.Fatal("missing chat {model} span")
 	}
 	if chat.Status.Code != codes.Error {
 		t.Errorf("status code = %v, want Error", chat.Status.Code)
@@ -263,9 +290,9 @@ func TestHook_ChatSpanRecordsHostOnly(t *testing.T) {
 		HookMeta: meta, Model: "claude-3", BaseURL: base, Duration: time.Second,
 	})
 
-	chat, ok := spanByName(endedStubs(sr), "gen_ai.chat")
+	chat, ok := spanByName(endedStubs(sr), "chat claude-3")
 	if !ok {
-		t.Fatal("missing gen_ai.chat span")
+		t.Fatal("missing chat {model} span")
 	}
 	if v, _ := attrValue(chat, "server.address"); v.AsString() != "gw.example.com:8443" {
 		t.Errorf("server.address = %q, want the host only", v.AsString())
@@ -331,9 +358,9 @@ func TestHook_ToolSpanErrorKind(t *testing.T) {
 			h, sr := newRecordingHook(t, false)
 			driveToolCall(h, "sess-kind", tc.post)
 
-			span, ok := spanByName(endedStubs(sr), "gen_ai.execute_tool")
+			span, ok := spanByName(endedStubs(sr), "execute_tool bash")
 			if !ok {
-				t.Fatal("missing gen_ai.execute_tool span")
+				t.Fatal("missing execute_tool {tool} span")
 			}
 			if v, ok := attrValue(span, "stella.tool.error_kind"); !ok || v.AsString() != tc.wantKind {
 				t.Errorf("error_kind = %q (ok=%v), want %q", v.AsString(), ok, tc.wantKind)
@@ -359,9 +386,9 @@ func TestHook_ToolSpanSuccessCarriesNoErrorKind(t *testing.T) {
 	h, sr := newRecordingHook(t, false)
 	driveToolCall(h, "sess-ok", hooks.PostToolCallContext{Result: "found"})
 
-	span, ok := spanByName(endedStubs(sr), "gen_ai.execute_tool")
+	span, ok := spanByName(endedStubs(sr), "execute_tool bash")
 	if !ok {
-		t.Fatal("missing gen_ai.execute_tool span")
+		t.Fatal("missing execute_tool {tool} span")
 	}
 	if v, ok := attrValue(span, "stella.tool.error_kind"); ok {
 		t.Errorf("successful tool span carries error_kind %q", v.AsString())
@@ -382,9 +409,9 @@ func TestHook_ChatSpanRecordsProviderAttempts(t *testing.T) {
 		TimeToFirstToken: 250 * time.Millisecond, Attempts: 3,
 	})
 
-	chat, ok := spanByName(endedStubs(sr), "gen_ai.chat")
+	chat, ok := spanByName(endedStubs(sr), "chat claude-3")
 	if !ok {
-		t.Fatal("missing gen_ai.chat span")
+		t.Fatal("missing chat {model} span")
 	}
 	if v, ok := attrValue(chat, "stella.llm.attempts"); !ok || v.AsInt64() != 3 {
 		t.Errorf("attempts = %d (ok=%v), want 3", v.AsInt64(), ok)
@@ -413,14 +440,14 @@ func TestHook_ProviderToolSurfaceAndLogCorrelation(t *testing.T) {
 		HookMeta: meta, CallID: "call", Model: "model", API: "provider",
 		ProviderToolNames: []string{"bash", "code"}, CodeCatalogSize: 12,
 	})
-	chat, ok := spanByName(endedStubs(sr), "gen_ai.chat")
+	chat, ok := spanByName(endedStubs(sr), "chat model")
 	if !ok {
-		t.Fatal("missing gen_ai.chat span")
+		t.Fatal("missing chat {model} span")
 	}
-	if got, ok := attrValue(chat, "gen_ai.request.tool_names"); !ok || got.AsStringSlice() == nil || strings.Join(got.AsStringSlice(), ",") != "bash,code" {
+	if got, ok := attrValue(chat, "stella.llm.provider_tool_names"); !ok || got.AsStringSlice() == nil || strings.Join(got.AsStringSlice(), ",") != "bash,code" {
 		t.Fatalf("provider tool names = %v (ok=%v)", got, ok)
 	}
-	if got, ok := attrValue(chat, "gen_ai.request.tool_count"); !ok || got.AsInt64() != 2 {
+	if got, ok := attrValue(chat, "stella.llm.provider_tool_count"); !ok || got.AsInt64() != 2 {
 		t.Fatalf("provider tool count = %v (ok=%v)", got, ok)
 	}
 	if got, ok := attrValue(chat, "stella.code.catalog_size"); !ok || got.AsInt64() != 12 {
@@ -437,7 +464,7 @@ func TestHook_ChatSpanOmitsUncountedAttempts(t *testing.T) {
 	_, _ = h.OnPreLLMCall(context.Background(), &hooks.PreLLMCallContext{HookMeta: meta, Model: "claude-3"})
 	h.OnPostLLMCall(context.Background(), &hooks.PostLLMCallContext{HookMeta: meta, Model: "claude-3"})
 
-	chat, _ := spanByName(endedStubs(sr), "gen_ai.chat")
+	chat, _ := spanByName(endedStubs(sr), "chat claude-3")
 	if _, ok := attrValue(chat, "stella.llm.attempts"); ok {
 		t.Error("attempts recorded when nothing counted them")
 	}

--- a/internal/reflect/trace.go
+++ b/internal/reflect/trace.go
@@ -2,12 +2,12 @@ package reflect
 
 import (
 	"context"
-	"fmt"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
+
+	"github.com/CherryHQ/stella/internal/observability"
 )
 
 var tracer = otel.Tracer("stella/reflect")
@@ -58,7 +58,5 @@ func startUsageCuratorSpan(ctx context.Context, pair usageCuratorPair, mode Usag
 
 // recordError records an error on a span and sets its status.
 func recordError(span trace.Span, err error) {
-	span.RecordError(err)
-	span.SetStatus(codes.Error, err.Error())
-	span.SetAttributes(attribute.String("error.type", fmt.Sprintf("%T", err)))
+	observability.RecordSpanError(span, err, "reflect operation failed")
 }

--- a/internal/scheduler/river.go
+++ b/internal/scheduler/river.go
@@ -52,6 +52,8 @@ type schedJobWorker struct {
 
 // Work implements river.Worker.
 func (w *schedJobWorker) Work(ctx context.Context, rjob *river.Job[schedJobArgs]) error {
+	ctx, jobSpan := startSchedulerJobSpan(ctx, rjob.Args.JobID, "", "", "")
+	defer jobSpan.End()
 	// Resolve the job fresh from the database rather than the local in-memory
 	// map: River workers consume the queue cluster-wide, so a job created,
 	// updated, or disabled on another node is only visible in the DB. Reading

--- a/internal/scheduler/service.go
+++ b/internal/scheduler/service.go
@@ -13,9 +13,6 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/riverqueue/river"
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/trace"
 
 	agentaccess "github.com/CherryHQ/stella/internal/agent/access"
 	"github.com/CherryHQ/stella/internal/authz"
@@ -756,15 +753,12 @@ func (s *Service) executeSingleRun(ctx context.Context, job Job, userID string, 
 		return
 	}
 
-	jobCtx, jobSpan := otel.Tracer("stella").Start(ctx, "scheduler.job",
-		trace.WithAttributes(
-			attribute.String("stella.scheduler.job_id", job.ID),
-			attribute.String("stella.scheduler.job_name", job.Name),
-			attribute.String("stella.scheduler.run_id", runID),
-			attribute.String("stella.scheduler.agent_id", job.AgentID),
-			attribute.String("stella.scheduler.dispatch_kind", job.DispatchKind),
-		))
-	defer jobSpan.End()
+	jobCtx := ctx
+	jobSpan := schedulerJobSpanFromContext(jobCtx)
+	if jobSpan == nil {
+		jobCtx, jobSpan = startSchedulerJobSpan(jobCtx, job.ID, runID, job.AgentID, job.DispatchKind)
+		defer jobSpan.End()
+	}
 	outputSink := &RunOutputSink{}
 	runCtx := withRunOutputSink(WithRunID(WithRunSessionID(jobCtx, sessionID), runID), outputSink)
 
@@ -785,7 +779,7 @@ func (s *Service) executeSingleRun(ctx context.Context, job Job, userID string, 
 	// Finalize run bookkeeping on a context detached from cancellation: when a
 	// graceful shutdown cancels ctx mid-dispatch, the run row must still move out
 	// of "running" so it neither stays stuck nor blocks the next fire.
-	bookkeepingCtx := context.WithoutCancel(ctx)
+	bookkeepingCtx := context.WithoutCancel(jobCtx)
 	if err := s.finishJobRun(bookkeepingCtx, runID, job.ID, status, finishedAt, errStr, outputSink.get()); err != nil {
 		s.log.Warn("failed to finish job run record", "run_id", runID, "error", err)
 	}
@@ -856,14 +850,7 @@ func (s *Service) RunJobNow(ctx context.Context, jobID string) (string, error) {
 	s.mu.Unlock()
 
 	go func() {
-		jobCtx, jobSpan := otel.Tracer("stella").Start(svcCtx, "scheduler.job",
-			trace.WithAttributes(
-				attribute.String("stella.scheduler.job_id", job.ID),
-				attribute.String("stella.scheduler.job_name", job.Name),
-				attribute.String("stella.scheduler.run_id", runID),
-				attribute.String("stella.scheduler.agent_id", job.AgentID),
-				attribute.String("stella.scheduler.dispatch_kind", job.DispatchKind),
-			))
+		jobCtx, jobSpan := startSchedulerJobSpan(svcCtx, job.ID, runID, job.AgentID, job.DispatchKind)
 		defer jobSpan.End()
 		outputSink := &RunOutputSink{}
 		runCtx := withRunOutputSink(WithRunID(WithRunSessionID(jobCtx, sessionID), runID), outputSink)
@@ -877,10 +864,11 @@ func (s *Service) RunJobNow(ctx context.Context, jobID string) (string, error) {
 			errStr = runErr.Error()
 		}
 
-		if err := s.finishJobRun(svcCtx, runID, jobID, status, finishedAt, errStr, outputSink.get()); err != nil {
+		bookkeepingCtx := context.WithoutCancel(jobCtx)
+		if err := s.finishJobRun(bookkeepingCtx, runID, jobID, status, finishedAt, errStr, outputSink.get()); err != nil {
 			s.log.Warn("failed to finish job run record", "run_id", runID, "error", err)
 		}
-		if err := s.recordJobRun(svcCtx, jobID, finishedAt, runErr); err != nil {
+		if err := s.recordJobRun(bookkeepingCtx, jobID, finishedAt, runErr); err != nil {
 			s.log.Warn("failed to record scheduler job run", "id", jobID, "error", err)
 		}
 

--- a/internal/scheduler/service.go
+++ b/internal/scheduler/service.go
@@ -13,6 +13,9 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/riverqueue/river"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 
 	agentaccess "github.com/CherryHQ/stella/internal/agent/access"
 	"github.com/CherryHQ/stella/internal/authz"
@@ -753,8 +756,17 @@ func (s *Service) executeSingleRun(ctx context.Context, job Job, userID string, 
 		return
 	}
 
+	jobCtx, jobSpan := otel.Tracer("stella").Start(ctx, "scheduler.job",
+		trace.WithAttributes(
+			attribute.String("stella.scheduler.job_id", job.ID),
+			attribute.String("stella.scheduler.job_name", job.Name),
+			attribute.String("stella.scheduler.run_id", runID),
+			attribute.String("stella.scheduler.agent_id", job.AgentID),
+			attribute.String("stella.scheduler.dispatch_kind", job.DispatchKind),
+		))
+	defer jobSpan.End()
 	outputSink := &RunOutputSink{}
-	runCtx := withRunOutputSink(WithRunID(WithRunSessionID(ctx, sessionID), runID), outputSink)
+	runCtx := withRunOutputSink(WithRunID(WithRunSessionID(jobCtx, sessionID), runID), outputSink)
 
 	// Inject user into job copy so the callback can read job.UserID correctly.
 	jobRun := job
@@ -844,8 +856,17 @@ func (s *Service) RunJobNow(ctx context.Context, jobID string) (string, error) {
 	s.mu.Unlock()
 
 	go func() {
+		jobCtx, jobSpan := otel.Tracer("stella").Start(svcCtx, "scheduler.job",
+			trace.WithAttributes(
+				attribute.String("stella.scheduler.job_id", job.ID),
+				attribute.String("stella.scheduler.job_name", job.Name),
+				attribute.String("stella.scheduler.run_id", runID),
+				attribute.String("stella.scheduler.agent_id", job.AgentID),
+				attribute.String("stella.scheduler.dispatch_kind", job.DispatchKind),
+			))
+		defer jobSpan.End()
 		outputSink := &RunOutputSink{}
-		runCtx := withRunOutputSink(WithRunID(WithRunSessionID(svcCtx, sessionID), runID), outputSink)
+		runCtx := withRunOutputSink(WithRunID(WithRunSessionID(jobCtx, sessionID), runID), outputSink)
 		runErr := s.dispatchJob(runCtx, job)
 
 		finishedAt := time.Now().UTC()

--- a/internal/scheduler/trace.go
+++ b/internal/scheduler/trace.go
@@ -1,0 +1,27 @@
+package scheduler
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type schedulerJobSpanKey struct{}
+
+func startSchedulerJobSpan(ctx context.Context, jobID, runID, agentID, dispatchKind string) (context.Context, trace.Span) {
+	ctx, span := otel.Tracer("stella").Start(ctx, "scheduler.job",
+		trace.WithAttributes(
+			attribute.String("stella.scheduler.job_id", jobID),
+			attribute.String("stella.scheduler.run_id", runID),
+			attribute.String("stella.scheduler.agent_id", agentID),
+			attribute.String("stella.scheduler.dispatch_kind", dispatchKind),
+		))
+	return context.WithValue(ctx, schedulerJobSpanKey{}, span), span
+}
+
+func schedulerJobSpanFromContext(ctx context.Context) trace.Span {
+	span, _ := ctx.Value(schedulerJobSpanKey{}).(trace.Span)
+	return span
+}

--- a/pkg/agent/code_strategy.go
+++ b/pkg/agent/code_strategy.go
@@ -9,11 +9,13 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 
 	"github.com/CherryHQ/stella/pkg/ai"
 	"github.com/CherryHQ/stella/pkg/codemode"
 	"github.com/CherryHQ/stella/pkg/hooks"
 	"github.com/CherryHQ/stella/pkg/renderrefs"
+	pkgtools "github.com/CherryHQ/stella/pkg/tools"
 )
 
 // CodeToolName is the one provider-facing entry point for every tool outside
@@ -449,12 +451,7 @@ func executeCodeModeCalls(ctx context.Context, calls []ai.ToolCall, directTools,
 			if cb.onStart != nil {
 				cb.onStart(call)
 			}
-			var result ai.ToolResultMessage
-			if codeTools == nil {
-				result = codeErrorResult(ai.ToolResultMessage{ToolCallID: call.ID, ToolName: call.Name}, "tool not available")
-			} else {
-				result = executeCodeCallWithCallbacks(ctx, call, codeTools, codeDefinitions, cb, hs, meta, lifecycle, canonicalize)
-			}
+			result := executeCodeCallWithCallbacks(ctx, call, codeTools, codeDefinitions, cb, hs, meta, lifecycle, canonicalize)
 			results = append(results, result)
 			if cb.onFinish != nil {
 				cb.onFinish(result)
@@ -481,13 +478,65 @@ func executeCodeCallWithCallbacks(ctx context.Context, call ai.ToolCall, tools T
 }
 
 func executeCodeCallWithLimitsAndCallbacks(ctx context.Context, call ai.ToolCall, tools ToolSet, definitions []ai.ToolDefinition, cb toolCallbacks, hs *hooks.HookSet, meta hooks.HookMeta, lifecycle *ToolLifecycle, canonicalize ToolImageCanonicalizer, limits codemode.Limits) ai.ToolResultMessage {
-	result := ai.ToolResultMessage{ToolCallID: call.ID, ToolName: call.Name}
-	if call.Name != codeToolName {
-		return codeErrorResult(result, "tool not found")
+	start := time.Now()
+	args := call.Arguments
+	execCtx := ctx
+	post := func(result ai.ToolResultMessage) ai.ToolResultMessage {
+		if hs == nil || hs.Empty() {
+			return result
+		}
+		kind := result.ErrorKind
+		if result.IsError && kind == "" {
+			kind = ai.ToolErrorKindTool
+		}
+		details, _ := result.Details.(codeExecutionDetails)
+		hs.RunPostToolCall(execCtx, &hooks.PostToolCallContext{
+			HookMeta:           meta,
+			ToolName:           call.Name,
+			ToolCallID:         call.ID,
+			Arguments:          args,
+			Result:             ai.FlattenText(result.Content),
+			IsError:            result.IsError,
+			ErrorKind:          kind,
+			Duration:           time.Since(start),
+			ChildToolCallAudit: childToolAudit(details, result.ChildToolCalls),
+		})
+		return result
 	}
-	source, ok := call.Arguments["code"].(string)
+	result := ai.ToolResultMessage{ToolCallID: call.ID, ToolName: call.Name}
+	pre := hooks.PreToolCallResult{}
+	if hs != nil && !hs.Empty() {
+		pre = hs.RunPreToolCall(ctx, &hooks.PreToolCallContext{
+			HookMeta:   meta,
+			ToolName:   call.Name,
+			ToolCallID: call.ID,
+			Arguments:  args,
+		})
+		if pre.Context != nil {
+			execCtx = pre.Context
+		}
+		if pre.Arguments != nil {
+			args = pre.Arguments
+		}
+		if pre.Block {
+			message := pre.BlockMessage
+			if message == "" {
+				message = "tool call blocked by hook"
+			}
+			return post(codeErrorResult(ai.ToolResultMessage{ToolCallID: call.ID, ToolName: call.Name}, message))
+		}
+	}
+	execCtx = pkgtools.WithParentImageCapability(execCtx, pkgtools.ParentImageCapabilityFromContext(ctx))
+
+	if call.Name != codeToolName {
+		return post(codeErrorResult(result, "tool not found"))
+	}
+	source, ok := args["code"].(string)
 	if !ok {
-		return codeErrorResult(result, "code tool requires a string code argument")
+		return post(codeErrorResult(result, "code tool requires a string code argument"))
+	}
+	if tools == nil {
+		return post(codeErrorResult(result, "tool not available"))
 	}
 	host := &codeHost{
 		outerID:      call.ID,
@@ -501,21 +550,31 @@ func executeCodeCallWithLimitsAndCallbacks(ctx context.Context, call ai.ToolCall
 	defer host.releaseIssuedImages()
 	executor, err := codemode.NewExecutor(host, limits, newCodeCatalog(definitions)...)
 	if err != nil {
-		return codeErrorResult(result, err.Error())
+		return post(codeErrorResult(result, err.Error()))
 	}
-	execution, err := executor.Run(ctx, source)
+	execution, err := executor.Run(hooks.WithToolParent(execCtx), source)
 	if err != nil {
 		result.ChildToolCalls = append([]ai.ChildToolCallAudit(nil), host.childAudit...)
-		return codeExecutionError(result, host, err)
+		return post(codeExecutionError(result, host, err))
 	}
 	result.References = dedupeReferences(host.references)
 	result, err = codeResultFromJSONStrictWithIssuedImages(result, execution.JSON, host.issuedImages)
 	if err != nil {
 		result.ChildToolCalls = append([]ai.ChildToolCallAudit(nil), host.childAudit...)
-		return codeExecutionError(result, host, err)
+		return post(codeExecutionError(result, host, err))
 	}
 	result.ChildToolCalls = append([]ai.ChildToolCallAudit(nil), host.childAudit...)
-	return result
+	return post(result)
+}
+
+func childToolAudit(details codeExecutionDetails, children []ai.ChildToolCallAudit) hooks.ChildToolCallAudit {
+	audit := hooks.ChildToolCallAudit{Count: len(children), FailureClass: details.Code}
+	for _, child := range children {
+		if child.IsError {
+			audit.ErrorCount++
+		}
+	}
+	return audit
 }
 
 func codeErrorResult(result ai.ToolResultMessage, message string) ai.ToolResultMessage {

--- a/pkg/agent/code_strategy_test.go
+++ b/pkg/agent/code_strategy_test.go
@@ -529,8 +529,8 @@ func TestCodeStrategyUsesEffectiveSnapshotAndSharedChildCore(t *testing.T) {
 	if len(toolCalls) != 1 || toolCalls[0].ID != "outer:1" {
 		t.Fatalf("child calls = %#v, want child ID outer:1", toolCalls)
 	}
-	if hook.postCalls != 1 {
-		t.Fatalf("PostToolCall count = %d, want 1", hook.postCalls)
+	if hook.postCalls != 2 {
+		t.Fatalf("PostToolCall count = %d, want outer and child (2)", hook.postCalls)
 	}
 	if len(history) != 4 {
 		t.Fatalf("history length = %d, want user + outer call/result + final assistant", len(history))
@@ -660,7 +660,10 @@ func TestCodeStrategyRejectsBlockedChildren(t *testing.T) {
 			name: "hook block",
 			want: "hook block",
 			hooks: hooks.NewHookSet([]hooks.HookPlugin{toolExecutionHook{
-				pre: func(context.Context, *hooks.PreToolCallContext) (hooks.PreToolCallResult, error) {
+				pre: func(_ context.Context, hctx *hooks.PreToolCallContext) (hooks.PreToolCallResult, error) {
+					if hctx.ToolName == codeToolName {
+						return hooks.PreToolCallResult{}, nil
+					}
 					return hooks.PreToolCallResult{Block: true, BlockMessage: "hook block"}, nil
 				},
 				post: func(context.Context, *hooks.PostToolCallContext) {},
@@ -971,7 +974,7 @@ func TestCodeChildUsesNativeLifecycleOrderWithoutChildCallbacks(t *testing.T) {
 	if len(results) != 1 || results[0].IsError {
 		t.Fatalf("results = %#v", results)
 	}
-	if got, want := strings.Join(order, ","), "outer-start,before,pre,tool,after,post,canonicalize,outer-finish"; got != want {
+	if got, want := strings.Join(order, ","), "outer-start,pre,before,pre,tool,after,post,canonicalize,post,outer-finish"; got != want {
 		t.Fatalf("order = %s, want %s", got, want)
 	}
 }

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -133,6 +133,7 @@ func runLoop(ctx context.Context, cfg loopConfig, history []ai.Message, activeSt
 		result, err := streamAssistant(streamCtx, normalized, turnCfg, emit)
 		duration := time.Since(start)
 		complete := result.Message
+		calls := extractToolCalls(complete)
 
 		// PostLLMCall hooks: telemetry / observation.
 		if !cfg.Hooks.Empty() {
@@ -149,6 +150,7 @@ func runLoop(ctx context.Context, cfg loopConfig, history []ai.Message, activeSt
 				Duration:          duration,
 				TimeToFirstToken:  result.TimeToFirstToken,
 				Attempts:          modelReq.Attempts(),
+				ToolCallCount:     len(calls),
 				ProviderToolNames: toolDefinitionNames(providerDefs),
 				CodeCatalogSize:   len(codeToolDefs),
 				Error:             err,
@@ -170,7 +172,6 @@ func runLoop(ctx context.Context, cfg loopConfig, history []ai.Message, activeSt
 			return history, nil
 		}
 
-		calls := extractToolCalls(complete)
 		if len(calls) == 0 {
 			if emit != nil {
 				emit(TurnFinished{Turn: turn})

--- a/pkg/agent/loop.go
+++ b/pkg/agent/loop.go
@@ -7,6 +7,9 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/google/uuid"
+	"go.opentelemetry.io/otel/trace"
+
 	"github.com/CherryHQ/stella/pkg/ai"
 	"github.com/CherryHQ/stella/pkg/hooks"
 	"github.com/CherryHQ/stella/pkg/tools"
@@ -44,6 +47,7 @@ func runLoop(ctx context.Context, cfg loopConfig, history []ai.Message, activeSt
 	loopStart := time.Now()
 	hydrationMemo := make(map[string]ai.ImageContent)
 	for turn := 1; ; turn++ {
+		callID := uuid.NewString()
 		if cfg.TurnNotify != nil {
 			if msg := cfg.TurnNotify(turn, time.Since(loopStart)); msg != nil {
 				history = append(history, ai.UserMessage{Content: *msg})
@@ -62,6 +66,7 @@ func runLoop(ctx context.Context, cfg loopConfig, history []ai.Message, activeSt
 		if !cfg.Hooks.Empty() {
 			preCtx := &hooks.PreLLMCallContext{
 				HookMeta:        cfg.HookMeta,
+				CallID:          callID,
 				Model:           cfg.Model.Name,
 				System:          cfg.System,
 				ToolDefinitions: cfg.ToolDefinitions,
@@ -72,7 +77,7 @@ func runLoop(ctx context.Context, cfg loopConfig, history []ai.Message, activeSt
 				MaxTokens:       cfg.StreamOptions.MaxTokens,
 				Temperature:     cfg.StreamOptions.Temperature,
 			}
-			hookResult, _ := cfg.Hooks.RunPreLLMCall(ctx, preCtx)
+			hookResult := cfg.Hooks.RunPreLLMCall(ctx, preCtx)
 			if hookResult.System != nil {
 				effectiveSystem = *hookResult.System
 			}
@@ -133,19 +138,22 @@ func runLoop(ctx context.Context, cfg loopConfig, history []ai.Message, activeSt
 		if !cfg.Hooks.Empty() {
 			usage := complete.Usage.WithCost(effectiveModel.Cost)
 			postCtx := &hooks.PostLLMCallContext{
-				HookMeta:         cfg.HookMeta,
-				Model:            effectiveModel.Name,
-				Provider:         effectiveModel.Provider,
-				API:              effectiveModel.API,
-				BaseURL:          effectiveModel.BaseURL,
-				Usage:            usage,
-				StopReason:       complete.StopReason,
-				Duration:         duration,
-				TimeToFirstToken: result.TimeToFirstToken,
-				Attempts:         modelReq.Attempts(),
-				Error:            err,
+				HookMeta:          cfg.HookMeta,
+				CallID:            callID,
+				Model:             effectiveModel.Name,
+				Provider:          effectiveModel.Provider,
+				API:               effectiveModel.API,
+				BaseURL:           effectiveModel.BaseURL,
+				Usage:             usage,
+				StopReason:        complete.StopReason,
+				Duration:          duration,
+				TimeToFirstToken:  result.TimeToFirstToken,
+				Attempts:          modelReq.Attempts(),
+				ProviderToolNames: toolDefinitionNames(providerDefs),
+				CodeCatalogSize:   len(codeToolDefs),
+				Error:             err,
 			}
-			cfg.Hooks.RunPostLLMCall(ctx, postCtx)
+			cfg.Hooks.RunPostLLMCall(streamCtx, postCtx)
 		}
 
 		if err != nil {
@@ -182,7 +190,10 @@ func runLoop(ctx context.Context, cfg loopConfig, history []ai.Message, activeSt
 			}
 		}
 
-		toolExecCtx := tools.WithParentImageCapability(ctx, turnCfg.Model.ImageCapability())
+		// Preserve only the provider span context for tool admission. Hook-local
+		// values from PreLLMCall must not leak into child tool handlers.
+		toolCtx := trace.ContextWithSpanContext(ctx, trace.SpanContextFromContext(streamCtx))
+		toolExecCtx := tools.WithParentImageCapability(toolCtx, turnCfg.Model.ImageCapability())
 		var canonicalizer ToolImageCanonicalizer
 		if cfg.CanonicalImages != nil {
 			canonicalizer = cfg.CanonicalImages.CanonicalizeToolResult
@@ -232,6 +243,14 @@ func runLoop(ctx context.Context, cfg loopConfig, history []ai.Message, activeSt
 			emit(TurnFinished{Turn: turn})
 		}
 	}
+}
+
+func toolDefinitionNames(defs []ai.ToolDefinition) []string {
+	names := make([]string, len(defs))
+	for i, def := range defs {
+		names[i] = def.Name
+	}
+	return names
 }
 
 func hasTerminalCodeResult(results []ai.ToolResultMessage) bool {

--- a/pkg/agent/tool_execution.go
+++ b/pkg/agent/tool_execution.go
@@ -44,22 +44,8 @@ func executeToolCalls(ctx context.Context, calls []ai.ToolCall, tools ToolSet, c
 			cb.onStart(call)
 		}
 
-		toolFn, ok := tools[call.Name]
-		if !ok {
-			result := ai.ToolResultMessage{
-				ToolCallID: call.ID,
-				ToolName:   call.Name,
-				IsError:    true,
-				ErrorKind:  ai.ToolErrorKindTool,
-				Content:    []ai.ContentBlock{ai.TextContent{Text: "tool not found"}},
-			}
-			if err := appendFinal(result); err != nil {
-				return results, err
-			}
-			continue
-		}
-
 		args := call.Arguments
+		start := time.Now()
 		if lifecycle != nil && lifecycle.BeforeCall != nil {
 			mutation, err := lifecycle.BeforeCall(ctx, ToolCallContext{
 				SessionID:  meta.SessionID,
@@ -148,6 +134,22 @@ func executeToolCalls(ctx context.Context, calls []ai.ToolCall, tools ToolSet, c
 			}
 		}
 
+		toolFn, ok := tools[call.Name]
+		if !ok {
+			result := ai.ToolResultMessage{
+				ToolCallID: call.ID,
+				ToolName:   call.Name,
+				IsError:    true,
+				ErrorKind:  ai.ToolErrorKindTool,
+				Content:    []ai.ContentBlock{ai.TextContent{Text: "tool not found"}},
+			}
+			runPostToolCall(execCtx, args, "tool not found", true, ai.ToolErrorKindTool, nil, time.Since(start))
+			if err := appendFinal(result); err != nil {
+				return results, err
+			}
+			continue
+		}
+
 		// Hooks may replace the context to establish span ancestry. Reapply the
 		// engine-owned image policy so observability cannot change tool routing.
 		execCtx = pkgtools.WithParentImageCapability(execCtx, pkgtools.ParentImageCapabilityFromContext(ctx))
@@ -158,7 +160,6 @@ func executeToolCalls(ctx context.Context, calls []ai.ToolCall, tools ToolSet, c
 		if cb.onExecute != nil {
 			cb.onExecute(execCall)
 		}
-		start := time.Now()
 		toolCtx := pkgchannel.WithNotificationAgentID(execCtx, meta.AgentID)
 		content, err := toolFn(toolCtx, execCall)
 		duration := time.Since(start)

--- a/pkg/agent/tool_execution.go
+++ b/pkg/agent/tool_execution.go
@@ -122,7 +122,7 @@ func executeToolCalls(ctx context.Context, calls []ai.ToolCall, tools ToolSet, c
 				ToolCallID: call.ID,
 				Arguments:  args,
 			}
-			preResult, _ := hs.RunPreToolCall(ctx, preCtx)
+			preResult := hs.RunPreToolCall(ctx, preCtx)
 			if preResult.Context != nil {
 				execCtx = preResult.Context
 			}

--- a/pkg/agent/tool_execution_test.go
+++ b/pkg/agent/tool_execution_test.go
@@ -377,6 +377,31 @@ func (h toolExecutionHook) OnPostToolCall(ctx context.Context, hctx *hooks.PostT
 	h.post(ctx, hctx)
 }
 
+func TestToolExecutionUnknownToolRunsHookEnvelope(t *testing.T) {
+	var pre, post int
+	var got hooks.PostToolCallContext
+	hs := hooks.NewHookSet([]hooks.HookPlugin{toolExecutionHook{
+		pre: func(_ context.Context, hctx *hooks.PreToolCallContext) (hooks.PreToolCallResult, error) {
+			pre++
+			if hctx.ToolName != "forged" {
+				t.Fatalf("pre tool = %q", hctx.ToolName)
+			}
+			return hooks.PreToolCallResult{}, nil
+		},
+		post: func(_ context.Context, hctx *hooks.PostToolCallContext) { post++; got = *hctx },
+	}})
+	results, err := executeToolCalls(context.Background(), []ai.ToolCall{{ID: "forged-call", Name: "forged"}}, ToolSet{}, toolCallbacks{}, hs, hooks.HookMeta{}, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pre != 1 || post != 1 || len(results) != 1 || !results[0].IsError {
+		t.Fatalf("pre=%d post=%d results=%#v", pre, post, results)
+	}
+	if got.ErrorKind != ai.ToolErrorKindTool || got.ToolName != "forged" {
+		t.Fatalf("post context = %#v", got)
+	}
+}
+
 // A command that ran and exited nonzero is the sandbox answering, not the tool
 // breaking. The distinction has to survive as a field: every consumer that
 // tried to recover it from the message text got it wrong.

--- a/pkg/hooks/hook.go
+++ b/pkg/hooks/hook.go
@@ -17,6 +17,7 @@ const (
 	PostToolCall   HookPoint = "post_tool_call"
 	PreLLMCall     HookPoint = "pre_llm_call"
 	PostLLMCall    HookPoint = "post_llm_call"
+	PreMemoryCall  HookPoint = "pre_memory_call"
 	PostMemoryCall HookPoint = "post_memory_call"
 )
 
@@ -25,7 +26,37 @@ type HookMeta struct {
 	SessionID string
 	UserID    string
 	AgentID   string
+	AgentName string
 	Channel   string
+	BindingID string
+}
+
+type (
+	toolParentContextKey struct{}
+	telemetryMetaKey     struct{}
+)
+
+// WithTelemetryMeta carries transport metadata into memory operations without
+// coupling the memory package to the agent runtime.
+func WithTelemetryMeta(ctx context.Context, channel, bindingID string) context.Context {
+	return context.WithValue(ctx, telemetryMetaKey{}, struct{ Channel, BindingID string }{channel, bindingID})
+}
+
+func TelemetryMetaFromContext(ctx context.Context) (channel, bindingID string) {
+	v, _ := ctx.Value(telemetryMetaKey{}).(struct{ Channel, BindingID string })
+	return v.Channel, v.BindingID
+}
+
+// WithToolParent marks a context whose current span should parent nested tool
+// calls, used by the Code Mode outer call. Ordinary native tools continue to
+// use the turn span as their parent.
+func WithToolParent(ctx context.Context) context.Context {
+	return context.WithValue(ctx, toolParentContextKey{}, true)
+}
+
+func HasToolParent(ctx context.Context) bool {
+	v, _ := ctx.Value(toolParentContextKey{}).(bool)
+	return v
 }
 
 // --- PreToolCall ---
@@ -56,13 +87,20 @@ type PreToolCallHook interface {
 // --- PostToolCall ---
 
 // PostToolCallContext is the typed payload for PostToolCall hooks.
+type ChildToolCallAudit struct {
+	Count        int
+	ErrorCount   int
+	FailureClass string
+}
+
 type PostToolCallContext struct {
 	HookMeta
-	ToolName   string
-	ToolCallID string
-	Arguments  map[string]any
-	Result     string
-	IsError    bool
+	ToolName           string
+	ToolCallID         string
+	Arguments          map[string]any
+	Result             string
+	IsError            bool
+	ChildToolCallAudit ChildToolCallAudit
 	// ErrorKind classifies IsError (#1077): the tool itself failed
 	// ("tool_error"), exited nonzero ("command_nonzero"), or hit its explicit
 	// command timeout ("command_timeout").
@@ -88,6 +126,7 @@ type PostToolCallHook interface {
 // PreLLMCallContext is the typed payload for PreLLMCall hooks.
 type PreLLMCallContext struct {
 	HookMeta
+	CallID          string
 	Model           string
 	System          string
 	ToolDefinitions []ai.ToolDefinition
@@ -121,14 +160,17 @@ type PreLLMCallHook interface {
 // PostLLMCallContext is the typed payload for PostLLMCall hooks.
 type PostLLMCallContext struct {
 	HookMeta
-	Model            string
-	Provider         string // provider display name (may be empty)
-	API              string // provider API key (e.g. "anthropic", "openai")
-	BaseURL          string // provider endpoint URL
-	Usage            ai.Usage
-	StopReason       ai.StopReason
-	Duration         time.Duration
-	TimeToFirstToken time.Duration // zero if no streaming or first token not observed
+	CallID            string
+	Model             string
+	ProviderToolNames []string
+	CodeCatalogSize   int
+	Provider          string // provider display name (may be empty)
+	API               string // provider API key (e.g. "anthropic", "openai")
+	BaseURL           string // provider endpoint URL
+	Usage             ai.Usage
+	StopReason        ai.StopReason
+	Duration          time.Duration
+	TimeToFirstToken  time.Duration // zero if no streaming or first token not observed
 	// Attempts is the number of provider HTTP requests this call took,
 	// including SDK-internal retries. 1 means no retry; 0 means nothing
 	// counted them (a stream that never went over HTTP, e.g. a test fake).

--- a/pkg/hooks/hook.go
+++ b/pkg/hooks/hook.go
@@ -26,7 +26,6 @@ type HookMeta struct {
 	SessionID string
 	UserID    string
 	AgentID   string
-	AgentName string
 	Channel   string
 	BindingID string
 }

--- a/pkg/hooks/hook.go
+++ b/pkg/hooks/hook.go
@@ -173,8 +173,9 @@ type PostLLMCallContext struct {
 	// Attempts is the number of provider HTTP requests this call took,
 	// including SDK-internal retries. 1 means no retry; 0 means nothing
 	// counted them (a stream that never went over HTTP, e.g. a test fake).
-	Attempts int
-	Error    error
+	Attempts      int
+	ToolCallCount int
+	Error         error
 }
 
 // PostLLMCallHook observes LLM call results (telemetry, cost tracking).

--- a/pkg/hooks/set.go
+++ b/pkg/hooks/set.go
@@ -100,9 +100,9 @@ func (hs *HookSet) RunPostAgentCall(ctx context.Context, hctx *PostAgentCallCont
 // Error policy: a failing hook is logged and skipped so that non-critical
 // hooks never block tool execution. Security-critical
 // checks must live in the core engine, not in disableable hook plugins.
-func (hs *HookSet) RunPreToolCall(ctx context.Context, hctx *PreToolCallContext) (PreToolCallResult, error) {
+func (hs *HookSet) RunPreToolCall(ctx context.Context, hctx *PreToolCallContext) PreToolCallResult {
 	if hs == nil {
-		return PreToolCallResult{}, nil
+		return PreToolCallResult{}
 	}
 	var final PreToolCallResult
 	for _, h := range hs.preToolCall {
@@ -122,10 +122,10 @@ func (hs *HookSet) RunPreToolCall(ctx context.Context, hctx *PreToolCallContext)
 		if result.Block {
 			final.Block = true
 			final.BlockMessage = result.BlockMessage
-			return final, nil
+			return final
 		}
 	}
-	return final, nil
+	return final
 }
 
 // RunPostToolCall executes all PostToolCall hooks in priority order.
@@ -143,9 +143,9 @@ func (hs *HookSet) RunPostToolCall(ctx context.Context, hctx *PostToolCallContex
 // Mutations from each hook are applied before the next hook runs.
 //
 // Error policy: same as RunPreToolCall — log and skip.
-func (hs *HookSet) RunPreLLMCall(ctx context.Context, hctx *PreLLMCallContext) (PreLLMCallResult, error) {
+func (hs *HookSet) RunPreLLMCall(ctx context.Context, hctx *PreLLMCallContext) PreLLMCallResult {
 	if hs == nil {
-		return PreLLMCallResult{}, nil
+		return PreLLMCallResult{}
 	}
 	var final PreLLMCallResult
 	for _, h := range hs.preLLMCall {
@@ -171,7 +171,7 @@ func (hs *HookSet) RunPreLLMCall(ctx context.Context, hctx *PreLLMCallContext) (
 			final.Context = result.Context
 		}
 	}
-	return final, nil
+	return final
 }
 
 // RunPostLLMCall executes all PostLLMCall hooks in priority order.
@@ -189,9 +189,9 @@ func (hs *HookSet) RunPostLLMCall(ctx context.Context, hctx *PostLLMCallContext)
 // Mutations from each hook are applied before the next hook runs.
 //
 // Error policy: same as RunPreToolCall — log and skip.
-func (hs *HookSet) RunPreMemoryCall(ctx context.Context, hctx *PreMemoryCallContext) (PreMemoryCallResult, error) {
+func (hs *HookSet) RunPreMemoryCall(ctx context.Context, hctx *PreMemoryCallContext) PreMemoryCallResult {
 	if hs == nil {
-		return PreMemoryCallResult{}, nil
+		return PreMemoryCallResult{}
 	}
 	var final PreMemoryCallResult
 	for _, h := range hs.preMemoryCall {
@@ -205,7 +205,7 @@ func (hs *HookSet) RunPreMemoryCall(ctx context.Context, hctx *PreMemoryCallCont
 			final.Context = result.Context
 		}
 	}
-	return final, nil
+	return final
 }
 
 // RunPostMemoryCall executes all PostMemoryCall hooks in priority order.

--- a/pkg/hooks/set_test.go
+++ b/pkg/hooks/set_test.go
@@ -156,10 +156,7 @@ func TestRunPreToolCall_RewriteChaining(t *testing.T) {
 		Arguments: map[string]any{"command": "original"},
 	}
 
-	result, err := hs.RunPreToolCall(context.Background(), hctx)
-	if err != nil {
-		t.Fatal(err)
-	}
+	result := hs.RunPreToolCall(context.Background(), hctx)
 	if !h1.called || !h2.called {
 		t.Error("both hooks should have been called")
 	}
@@ -189,10 +186,7 @@ func TestRunPreToolCall_ContextChaining(t *testing.T) {
 		},
 	}
 
-	result, err := NewHookSet([]HookPlugin{first, second}).RunPreToolCall(context.Background(), &PreToolCallContext{})
-	if err != nil {
-		t.Fatal(err)
-	}
+	result := NewHookSet([]HookPlugin{first, second}).RunPreToolCall(context.Background(), &PreToolCallContext{})
 	if result.Context == nil || result.Context.Value(key) != "parent" {
 		t.Fatalf("result context did not preserve chained value")
 	}
@@ -211,10 +205,7 @@ func TestRunPreToolCall_BlockShortCircuits(t *testing.T) {
 	hs := NewHookSet([]HookPlugin{h1, h2})
 	hctx := &PreToolCallContext{ToolName: "bash", Arguments: map[string]any{}}
 
-	result, err := hs.RunPreToolCall(context.Background(), hctx)
-	if err != nil {
-		t.Fatal(err)
-	}
+	result := hs.RunPreToolCall(context.Background(), hctx)
 	if !result.Block {
 		t.Error("expected block=true")
 	}
@@ -261,10 +252,7 @@ func TestRunPreLLMCall_ContextChaining(t *testing.T) {
 		},
 	}
 
-	result, err := NewHookSet([]HookPlugin{first, second}).RunPreLLMCall(context.Background(), &PreLLMCallContext{})
-	if err != nil {
-		t.Fatal(err)
-	}
+	result := NewHookSet([]HookPlugin{first, second}).RunPreLLMCall(context.Background(), &PreLLMCallContext{})
 	if result.Context == nil || result.Context.Value(key) != "span" {
 		t.Fatalf("result context did not preserve chained value")
 	}
@@ -283,10 +271,7 @@ func TestRunPreLLMCall_SystemOverride(t *testing.T) {
 		System: "original",
 	}
 
-	result, err := hs.RunPreLLMCall(context.Background(), hctx)
-	if err != nil {
-		t.Fatal(err)
-	}
+	result := hs.RunPreLLMCall(context.Background(), hctx)
 	if !h.called {
 		t.Error("hook should be called")
 	}
@@ -320,15 +305,15 @@ func TestRunPostLLMCall_Telemetry(t *testing.T) {
 func TestNilHookSet_NoOp(t *testing.T) {
 	var hs *HookSet
 
-	result, err := hs.RunPreToolCall(context.Background(), &PreToolCallContext{})
-	if err != nil || result.Block {
+	result := hs.RunPreToolCall(context.Background(), &PreToolCallContext{})
+	if result.Block {
 		t.Error("nil set should be no-op")
 	}
 
 	hs.RunPostToolCall(context.Background(), &PostToolCallContext{})
 
-	llmResult, err := hs.RunPreLLMCall(context.Background(), &PreLLMCallContext{})
-	if err != nil || llmResult.System != nil {
+	llmResult := hs.RunPreLLMCall(context.Background(), &PreLLMCallContext{})
+	if llmResult.System != nil {
 		t.Error("nil set should be no-op")
 	}
 
@@ -446,10 +431,7 @@ func TestRunPreMemoryCall(t *testing.T) {
 	}
 	hs := NewHookSet([]HookPlugin{h})
 
-	result, err := hs.RunPreMemoryCall(context.Background(), &PreMemoryCallContext{Op: MemoryOpAppend})
-	if err != nil {
-		t.Fatal(err)
-	}
+	result := hs.RunPreMemoryCall(context.Background(), &PreMemoryCallContext{Op: MemoryOpAppend})
 	if !h.called {
 		t.Error("expected hook to be called")
 	}
@@ -463,8 +445,8 @@ func TestRunPreMemoryCall(t *testing.T) {
 
 func TestRunPreMemoryCall_Nil(t *testing.T) {
 	var hs *HookSet
-	result, err := hs.RunPreMemoryCall(context.Background(), &PreMemoryCallContext{})
-	if err != nil || result.Context != nil {
+	result := hs.RunPreMemoryCall(context.Background(), &PreMemoryCallContext{})
+	if result.Context != nil {
 		t.Fatal("nil hook set should be no-op")
 	}
 }

--- a/plugins/sandbox/docker/trace.go
+++ b/plugins/sandbox/docker/trace.go
@@ -1,13 +1,11 @@
 package docker
 
 import (
-	"fmt"
-
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/CherryHQ/stella/internal/observability"
 	sandboxpkg "github.com/CherryHQ/stella/pkg/sandbox"
 )
 
@@ -27,7 +25,5 @@ func recordError(span trace.Span, err error) {
 	if span == nil || err == nil {
 		return
 	}
-	span.RecordError(err)
-	span.SetStatus(codes.Error, err.Error())
-	span.SetAttributes(attribute.String("error.type", fmt.Sprintf("%T", err)))
+	observability.RecordSpanError(span, err, "sandbox operation failed")
 }

--- a/web/content/docs/guides/observability.md
+++ b/web/content/docs/guides/observability.md
@@ -49,7 +49,7 @@ LOG_LEVEL_RIVER=DEBUG stellad server
 
 ### OpenTelemetry Mode
 
-Set `OTEL_EXPORTER_OTLP_ENDPOINT` to enable traces, logs, and metrics together, or use signal-specific exporter variables to enable only some signals. Metrics cover the HTTP server (request counts, durations) and the Go runtime (memory, GC, goroutines). If the backend does not support the logs service (e.g. Jaeger), Stella detects the first failure and silently disables log export. Stella delegates exporter configuration to the OpenTelemetry SDK, so standard OTel environment variables are supported:
+Set `OTEL_EXPORTER_OTLP_ENDPOINT` to enable traces, logs, and metrics together, or use signal-specific exporter variables to enable only some signals. Metrics cover the HTTP server (request counts, durations), the Go runtime (memory, GC, goroutines), and the domain instruments listed below. If the backend does not support the logs service (e.g. Jaeger), Stella detects the first failure and silently disables log export. Stella delegates exporter configuration to the OpenTelemetry SDK, so standard OTel environment variables are supported:
 
 | Environment Variable                 | Default                    | Description                                                                                                                                                                                               |
 | ------------------------------------ | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -61,14 +61,42 @@ Set `OTEL_EXPORTER_OTLP_ENDPOINT` to enable traces, logs, and metrics together, 
 | `OTEL_EXPORTER_OTLP_TRACES_HEADERS`  | _(empty)_                  | Comma-separated headers applied to traces only. Overrides generic OTLP headers for traces.                                                                                                                |
 | `OTEL_EXPORTER_OTLP_LOGS_HEADERS`    | _(empty)_                  | Comma-separated headers applied to logs only. Overrides generic OTLP headers for logs.                                                                                                                    |
 | `OTEL_TRACES_EXPORTER`               | SDK default                | Trace exporter. Set to `none` to disable trace export while keeping other OTel signals available.                                                                                                         |
+| `OTEL_TRACES_SAMPLER`                | SDK default                | Trace sampling strategy, for example `parentbased_traceidratio`.                                                                                                                                          |
+| `OTEL_TRACES_SAMPLER_ARG`            | SDK default                | Sampling argument, for example `0.1` for a 10% trace ratio.                                                                                                                                               |
 | `OTEL_LOGS_EXPORTER`                 | SDK default                | Log exporter. Set to `none` to disable log export while keeping traces available.                                                                                                                         |
 | `OTEL_METRICS_EXPORTER`              | SDK default                | Metric exporter. Set to `none` to disable metric export while keeping other OTel signals available.                                                                                                       |
 | `OTEL_SERVICE_NAME`                  | `stella`                   | Service name shown in your observability backend.                                                                                                                                                         |
 | `OTEL_RESOURCE_ATTRIBUTES`           | _(empty)_                  | Extra resource attributes attached to every signal, for example `deployment.environment=prod`.                                                                                                            |
 | `OTEL_EXPORTER_OTLP_INSECURE`        | SDK default                | Set to `false` to require TLS. Use `false` for HTTPS or secure gRPC endpoints.                                                                                                                            |
+| `OTEL_STELLA_RECORD_DB_QUERIES`      | `false`                    | Set to `true` to opt in to per-query PostgreSQL client spans. It is off by default because query spans are numerous and include `db.statement`.                                                           |
 | `OTEL_STELLA_RECORD_TOOL_IO`         | `false`                    | Set to `true` to record tool input (e.g. bash commands) and result text on spans. Off by default so this content is never exported; spans always carry tool name, argument count, and result length.      |
 
-When OTel is enabled, both modes run simultaneously -- you get stderr log lines plus exported traces, logs, and metrics. Log lines written on a traced path (LLM calls, tool calls, HTTP requests) carry `trace_id` and `span_id`, so you can jump from a stderr line straight to the trace in your backend.
+When OTel is enabled, both modes run simultaneously -- you get stderr log lines plus exported traces, logs, and metrics. Log lines written on a traced path (LLM calls, tool calls, HTTP requests) carry `trace_id` and `span_id` when their context contains a span, so you can jump from a stderr line straight to the trace in your backend. Exported logs use the same tee handler as stderr.
+
+### Domain Metrics
+
+When metrics export is enabled, Stella records these domain instruments from the same agent-loop hook payloads. Durations use seconds; token and count instruments use their named units. No metric uses `session_id`, `user_id`, call IDs, URLs, arguments, results, or error messages as labels.
+
+| Instrument                       | Type / unit          | Labels                                                                                              |
+| -------------------------------- | -------------------- | --------------------------------------------------------------------------------------------------- |
+| `stella.llm.call.duration`       | histogram, s         | `model`, `provider`, `agent_id`, `channel`                                                          |
+| `stella.llm.time_to_first_token` | histogram, s         | `model`, `provider`, `agent_id`, `channel`                                                          |
+| `stella.llm.tokens`              | counter, token       | `model`, `provider`, `type` (`input`, `output`, `cache_read`, `cache_write`), `agent_id`, `channel` |
+| `stella.llm.cost`                | counter, USD         | `model`, `provider`, `agent_id`, `channel`                                                          |
+| `stella.llm.calls`               | counter, call        | `model`, `provider`, `stop_reason`, `error.type`, `agent_id`, `channel`                             |
+| `stella.llm.attempts`            | counter, attempt     | `model`, `provider`, `agent_id`, `channel`                                                          |
+| `stella.tool.call.duration`      | histogram, s         | `tool`, `is_error`, `error_kind`, `agent_id`, `channel`                                             |
+| `stella.tool.calls`              | counter, call        | `tool`, `is_error`, `error_kind`, `agent_id`, `channel`                                             |
+| `stella.agent.turn.duration`     | histogram, s         | `agent_id`, `channel`                                                                               |
+| `stella.agent.turns`             | counter, turn        | `agent_id`, `channel`, `error.type`                                                                 |
+| `stella.memory.op.duration`      | histogram, s         | `op`, `agent_id`, `channel`                                                                         |
+| `stella.llm_usage.queue.dropped` | counter, observation | none                                                                                                |
+| `stella.llm_usage.queue.depth`   | gauge, observation   | none                                                                                                |
+| `stella.trace.sessions.active`   | gauge, session       | none                                                                                                |
+
+In the development environment, set `OTEL_METRICS_EXPORTER=otlp` in `~/.stella-dev/.env` to export these metrics. `stella` does not modify that file.
+
+`model`, `provider`, `tool`, `channel`, `op`, `error_kind`, and `stop_reason` are bounded operational dimensions. The `channel` values are transport names such as `web`, `telegram`, `feishu`, `discord`, `qq`, `wechat`, `scheduler`, and `goal`.
 
 ### Common Pitfalls
 
@@ -239,19 +267,17 @@ Some integrations still call out through their own HTTP clients (several channel
 Spans are organized into a hierarchy per chat session:
 
 ```
-chat
-  └── turn 1
-       ├── gen_ai.chat                 3.2s
-       │    └── gen_ai.chat.request    0.4s
-       ├── gen_ai.execute_tool (bash)  1.5s
-       ├── gen_ai.execute_tool (bash)  0.1s
-       └── memory.append               0.02s
-  └── turn 2
-       ├── gen_ai.chat                 2.8s
-       └── memory.compact              0.2s
+channel.ingress / scheduler.job / goal.attempt
+  └── agent.loop
+       └── agent.turn
+            ├── gen_ai.chat             3.2s
+            │    └── gen_ai.chat.request 0.4s
+            ├── gen_ai.execute_tool    1.5s
+            │    └── gen_ai.execute_tool (child)
+            └── memory.append           0.02s
 ```
 
-A new **turn** starts each time stella calls the LLM. The **chat** root span covers the entire conversation and closes after 2 minutes of inactivity.
+A new **agent.turn** starts each time stella calls the LLM. `agent.loop` groups activity for one session and closes after 2 minutes of inactivity. Non-HTTP entry points use `channel.ingress`, `scheduler.job`, or `goal.attempt` as their root span.
 
 ## Span Attributes Reference
 
@@ -261,8 +287,8 @@ LLM and tool spans follow [OpenTelemetry GenAI semantic conventions](https://ope
 | ------------------------------------------ | ------------ | -------------------------------- |
 | `gen_ai.operation.name`                    | all          | `chat` or `execute_tool`         |
 | `gen_ai.request.attempt`                   | chat.request | Attempt number, from 1           |
-| `gen_ai.request.attempts`                  | chat         | Provider HTTP attempts           |
-| `gen_ai.request.retry_count`               | chat         | Attempts minus one               |
+| `stella.llm.attempts`                      | chat         | Provider HTTP attempts           |
+| `stella.llm.retry_count`                   | chat         | Attempts minus one               |
 | `gen_ai.provider.name`                     | chat         | Provider identifier              |
 | `gen_ai.request.model`                     | chat         | Requested model                  |
 | `gen_ai.response.model`                    | chat         | Actual model used                |
@@ -272,11 +298,11 @@ LLM and tool spans follow [OpenTelemetry GenAI semantic conventions](https://ope
 | `gen_ai.usage.output_tokens`               | chat         | Output tokens                    |
 | `gen_ai.usage.cache_read.input_tokens`     | chat         | Cached input tokens              |
 | `gen_ai.usage.cache_creation.input_tokens` | chat         | Tokens written to cache          |
-| `gen_ai.server.time_to_first_token`        | chat         | TTFT in seconds                  |
+| `stella.llm.time_to_first_token_s`         | chat         | TTFT in seconds                  |
 | `gen_ai.tool.name`                         | execute_tool | Tool name                        |
 | `gen_ai.tool.call.id`                      | execute_tool | Tool call ID                     |
-| `gen_ai.tool.error_kind`                   | execute_tool | `tool_error` / `command_nonzero` |
-| `gen_ai.tool.exit_code`                    | execute_tool | Command exit status              |
+| `stella.tool.error_kind`                   | execute_tool | `tool_error` / `command_nonzero` |
+| `stella.tool.exit_code`                    | execute_tool | Command exit status              |
 | `error.type`                               | all          | Error type on failure            |
 
 Memory spans use stella-specific attributes:

--- a/web/content/docs/guides/observability.md
+++ b/web/content/docs/guides/observability.md
@@ -17,11 +17,11 @@ Tracing is built into the server — there is nothing to enable on the Plugins p
 
 Log mode is always active. Control verbosity with `LOG_LEVEL`:
 
-| Level            | What You See                                                                                            |
-| ---------------- | ------------------------------------------------------------------------------------------------------- |
-| `INFO` (default) | Every LLM call (model, tokens, duration, TTFT), tool call (name, duration, error), and memory operation |
-| `DEBUG`          | Same as INFO plus internal engine events                                                                |
-| `TRACE`          | Same as DEBUG plus full memory operation details (message content, search results, profile text)        |
+| Level            | What You See                                                                                     |
+| ---------------- | ------------------------------------------------------------------------------------------------ |
+| `INFO` (default) | Every LLM call and tool call; session-scoped memory operations                                   |
+| `DEBUG`          | Same as INFO plus global/session-less memory operations and internal engine events               |
+| `TRACE`          | Same as DEBUG plus full memory operation details (message content, search results, profile text) |
 
 ```bash
 # Default -- LLM/tool/memory events at INFO
@@ -79,7 +79,7 @@ When metrics export is enabled, Stella records these domain instruments from the
 
 | Instrument                       | Type / unit          | Labels                                                                                              |
 | -------------------------------- | -------------------- | --------------------------------------------------------------------------------------------------- |
-| `stella.llm.call.duration`       | histogram, s         | `model`, `provider`, `agent_id`, `channel`                                                          |
+| `stella.llm.call.duration`       | histogram, s         | `model`, `provider`, `agent_id`, `channel`, `error.type`                                            |
 | `stella.llm.time_to_first_token` | histogram, s         | `model`, `provider`, `agent_id`, `channel`                                                          |
 | `stella.llm.tokens`              | counter, token       | `model`, `provider`, `type` (`input`, `output`, `cache_read`, `cache_write`), `agent_id`, `channel` |
 | `stella.llm.cost`                | counter, USD         | `model`, `provider`, `agent_id`, `channel`                                                          |
@@ -125,7 +125,7 @@ OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317 \
 stellad server
 ```
 
-Open `http://localhost:16686`, select the **stella** service, and click **Find Traces**. Each chat session appears as a trace with a waterfall view of LLM calls, tool executions, and memory operations. Jaeger focuses on traces; use a logs-capable backend or collector pipeline when you also want to search exported log records.
+Open `http://localhost:16686`, select the **stella** service, and click **Find Traces**. Each admitted agent call appears as a trace with a waterfall view of LLM calls, tool executions, and memory operations. Jaeger focuses on traces; use a logs-capable backend or collector pipeline when you also want to search exported log records.
 
 ### Using with Grafana LGTM
 
@@ -199,7 +199,7 @@ The response includes all call counts. Token totals are `null` if any call did n
 
 ### LLM Calls
 
-Every call to an LLM provider is captured as a `gen_ai.chat` span:
+Every call to an LLM provider is captured as a `chat {model}` span:
 
 - Model name (requested and actual)
 - Provider (anthropic, openai, etc.)
@@ -219,7 +219,7 @@ Every request through the shared HTTP client gets exactly one span, ending at th
 
 ### Tool Executions
 
-Each tool call is captured as a `gen_ai.execute_tool` span:
+Each tool call is captured as a `execute_tool {tool}` span:
 
 - Tool name (bash, view_image, webfetch, agent, etc.)
 - Call ID
@@ -264,20 +264,21 @@ Some integrations still call out through their own HTTP clients (several channel
 
 ### Trace Structure
 
-Spans are organized into a hierarchy per chat session:
+Spans are organized per admitted agent call:
 
 ```
-channel.ingress / scheduler.job / goal.attempt
-  └── agent.loop
-       └── agent.turn
-            ├── gen_ai.chat             3.2s
-            │    └── gen_ai.chat.request 0.4s
-            ├── gen_ai.execute_tool    1.5s
-            │    └── gen_ai.execute_tool (child)
-            └── memory.append           0.02s
+channel.ingress / scheduler.job / goal.attempt / http.server
+  └── agent.runner_get_or_create
+       └── agent.loop
+            └── agent.turn
+                 ├── chat {model}             3.2s
+                 │    └── gen_ai.chat.request 0.4s
+                 ├── execute_tool {tool}      1.5s
+                 │    └── execute_tool {tool} (child)
+                 └── memory.append             0.02s
 ```
 
-A new **agent.turn** starts each time stella calls the LLM. `agent.loop` groups activity for one session and closes after 2 minutes of inactivity. Non-HTTP entry points use `channel.ingress`, `scheduler.job`, or `goal.attempt` as their root span.
+A new **agent.turn** starts each time stella calls the LLM. `agent.loop` covers one admitted agent call and ends when that call's stream completes; the reaper only cleans up abandoned callbacks. Non-HTTP entry points use `channel.ingress`, `scheduler.job`, or `goal.attempt` as their root span. Guest sessions intentionally skip domain hooks and produce no domain telemetry.
 
 ## Span Attributes Reference
 
@@ -288,14 +289,16 @@ LLM and tool spans follow [OpenTelemetry GenAI semantic conventions](https://ope
 | `gen_ai.operation.name`                    | all          | `chat` or `execute_tool`         |
 | `gen_ai.request.attempt`                   | chat.request | Attempt number, from 1           |
 | `stella.llm.attempts`                      | chat         | Provider HTTP attempts           |
-| `stella.llm.retry_count`                   | chat         | Attempts minus one               |
-| `gen_ai.provider.name`                     | chat         | Provider identifier              |
-| `gen_ai.request.model`                     | chat         | Requested model                  |
-| `gen_ai.response.model`                    | chat         | Actual model used                |
-| `gen_ai.response.finish_reasons`           | chat         | Why generation stopped           |
+| `stella.llm.retry_count`                   | chat {model} | Attempts minus one               |
+| `stella.llm.provider_tool_names`           | chat {model} | Provider-facing tool names       |
+| `stella.llm.provider_tool_count`           | chat {model} | Provider-facing tool count       |
+| `gen_ai.provider.name`                     | chat {model} | Provider identifier              |
+| `gen_ai.request.model`                     | chat {model} | Requested model                  |
+| `gen_ai.response.model`                    | chat {model} | Actual model used                |
+| `gen_ai.response.finish_reasons`           | chat {model} | Why generation stopped           |
 | `gen_ai.conversation.id`                   | all          | Session ID                       |
-| `gen_ai.usage.input_tokens`                | chat         | Input tokens                     |
-| `gen_ai.usage.output_tokens`               | chat         | Output tokens                    |
+| `gen_ai.usage.input_tokens`                | chat {model} | Input tokens                     |
+| `gen_ai.usage.output_tokens`               | chat {model} | Output tokens                    |
 | `gen_ai.usage.cache_read.input_tokens`     | chat         | Cached input tokens              |
 | `gen_ai.usage.cache_creation.input_tokens` | chat         | Tokens written to cache          |
 | `stella.llm.time_to_first_token_s`         | chat         | TTFT in seconds                  |

--- a/web/content/docs/guides/observability.zh.md
+++ b/web/content/docs/guides/observability.zh.md
@@ -79,7 +79,7 @@ LOG_LEVEL_RIVER=DEBUG stellad server
 
 | 指标                             | 类型/单位            | Labels                                                                                               |
 | -------------------------------- | -------------------- | ---------------------------------------------------------------------------------------------------- |
-| `stella.llm.call.duration`       | histogram，s         | `model`、`provider`、`agent_id`、`channel`                                                           |
+| `stella.llm.call.duration`       | histogram，s         | `model`、`provider`、`agent_id`、`channel`、`error.type`                                             |
 | `stella.llm.time_to_first_token` | histogram，s         | `model`、`provider`、`agent_id`、`channel`                                                           |
 | `stella.llm.tokens`              | counter，token       | `model`、`provider`、`type`（`input`、`output`、`cache_read`、`cache_write`）、`agent_id`、`channel` |
 | `stella.llm.cost`                | counter，USD         | `model`、`provider`、`agent_id`、`channel`                                                           |
@@ -125,7 +125,7 @@ OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317 \
 stellad server
 ```
 
-打开 `http://localhost:16686`，选择 **stella** 服务，点击 **Find Traces**。每个对话会话都会显示为一条追踪，并以瀑布图展示 LLM 调用、工具执行和记忆操作。Jaeger 主要面向追踪；如果还要检索导出的日志，请使用支持日志的后端或采集器管道。
+打开 `http://localhost:16686`，选择 **stella** 服务，点击 **Find Traces**。每个已接纳的 agent 调用都会显示为一条追踪，并以瀑布图展示 LLM 调用、工具执行和记忆操作。Jaeger 主要面向追踪；如果还要检索导出的日志，请使用支持日志的后端或采集器管道。
 
 ### 配合 Grafana LGTM 使用
 
@@ -199,7 +199,7 @@ stellad server
 
 ### LLM 调用
 
-每次对 LLM 服务商的调用都会记录为 `gen_ai.chat` span：
+每次对 LLM 服务商的调用都会记录为 `chat {model}` span：
 
 - 模型名（请求的与实际的）
 - 服务商（anthropic、openai 等）
@@ -211,7 +211,7 @@ stellad server
 - 错误
 
 服务商 SDK 会在一次调用内部重试，因此每次网络请求都有自己的子 span
-`gen_ai.chat.request`，带上尝试序号、响应状态码与服务器主机名。它的耗时是请求
+`chat {model}.request`，带上尝试序号、响应状态码与服务器主机名。它的耗时是请求
 本身（连接、发送、首字节），不含流式响应——那是父 span 的耗时。
 
 经由共享 HTTP 客户端的每个请求恰好产生一个 span，在响应头返回时结束。非模型调用的请求走同一个
@@ -221,7 +221,7 @@ span，只是名字是通用的 `HTTP <METHOD>`；模型调用的 context 额外
 
 ### 工具执行
 
-每次工具调用都会记录为 `gen_ai.execute_tool` span：
+每次工具调用都会记录为 `execute_tool {tool}` span：
 
 - 工具名（bash、view_image、webfetch、agent 等）
 - 调用 ID
@@ -265,20 +265,21 @@ Web UI 与 API 的入站请求会记录为 `http.server` span，让你可以端�
 
 ### 追踪结构
 
-Span 按每个对话会话组织成层级结构：
+Span 按每个已接纳的 agent 调用组织成层级结构：
 
 ```
-channel.ingress / scheduler.job / goal.attempt
-  └── agent.loop
-       └── agent.turn
-            ├── gen_ai.chat             3.2s
-            │    └── gen_ai.chat.request 0.4s
-            ├── gen_ai.execute_tool    1.5s
-            │    └── gen_ai.execute_tool（子调用）
-            └── memory.append           0.02s
+channel.ingress / scheduler.job / goal.attempt / http.server
+  └── agent.runner_get_or_create
+       └── agent.loop
+            └── agent.turn
+                 ├── chat {model}             3.2s
+                 │    └── gen_ai.chat.request 0.4s
+                 ├── execute_tool {tool}      1.5s
+                 │    └── execute_tool {tool}（子调用）
+                 └── memory.append             0.02s
 ```
 
-每次 stella 调用 LLM 都会开始一个新的 **agent.turn**。`agent.loop` 组织一个会话的活动，在 2 分钟无活动后关闭。非 HTTP 入口使用 `channel.ingress`、`scheduler.job` 或 `goal.attempt` 作为根 span。
+每次 stella 调用 LLM 都会开始一个新的 **agent.turn**。`agent.loop` 覆盖一次已接纳的 agent 调用，在该调用的 stream 完成时关闭；reaper 只清理遗留回调。非 HTTP 入口使用 `channel.ingress`、`scheduler.job` 或 `goal.attempt` 作为根 span。Guest session 出于隐私设计跳过领域 hook，不产生领域 telemetry。
 
 ## Span 属性参考
 
@@ -288,18 +289,20 @@ LLM 与工具 span 遵循 [OpenTelemetry GenAI 语义约定](https://opentelemet
 | ------------------------------------------ | ------------ | -------------------------------- |
 | `gen_ai.operation.name`                    | 全部         | `chat` 或 `execute_tool`         |
 | `gen_ai.request.attempt`                   | chat.request | 尝试序号，从 1 开始              |
-| `gen_ai.request.attempts`                  | chat         | 服务商 HTTP 请求次数             |
-| `gen_ai.request.retry_count`               | chat         | 请求次数减一                     |
-| `gen_ai.provider.name`                     | chat         | 服务商标识                       |
-| `gen_ai.request.model`                     | chat         | 请求的模型                       |
-| `gen_ai.response.model`                    | chat         | 实际使用的模型                   |
-| `gen_ai.response.finish_reasons`           | chat         | 生成停止的原因                   |
+| `stella.llm.attempts`                      | chat {model} | 服务商 HTTP 请求次数             |
+| `stella.llm.retry_count`                   | chat {model} | 请求次数减一                     |
+| `stella.llm.provider_tool_names`           | chat {model} | 服务商实际收到的工具名           |
+| `stella.llm.provider_tool_count`           | chat {model} | 服务商实际收到的工具数量         |
+| `gen_ai.provider.name`                     | chat {model} | 服务商标识                       |
+| `gen_ai.request.model`                     | chat {model} | 请求的模型                       |
+| `gen_ai.response.model`                    | chat {model} | 实际使用的模型                   |
+| `gen_ai.response.finish_reasons`           | chat {model} | 生成停止的原因                   |
 | `gen_ai.conversation.id`                   | 全部         | 会话 ID                          |
-| `gen_ai.usage.input_tokens`                | chat         | 输入 token                       |
-| `gen_ai.usage.output_tokens`               | chat         | 输出 token                       |
+| `gen_ai.usage.input_tokens`                | chat {model} | 输入 token                       |
+| `gen_ai.usage.output_tokens`               | chat {model} | 输出 token                       |
 | `gen_ai.usage.cache_read.input_tokens`     | chat         | 缓存命中的输入 token             |
 | `gen_ai.usage.cache_creation.input_tokens` | chat         | 写入缓存的 token                 |
-| `gen_ai.server.time_to_first_token`        | chat         | TTFT（秒）                       |
+| `stella.llm.time_to_first_token_s`         | chat {model} | TTFT（秒）                       |
 | `gen_ai.tool.name`                         | execute_tool | 工具名                           |
 | `gen_ai.tool.call.id`                      | execute_tool | 工具调用 ID                      |
 | `stella.tool.error_kind`                   | execute_tool | `tool_error` / `command_nonzero` |

--- a/web/content/docs/guides/observability.zh.md
+++ b/web/content/docs/guides/observability.zh.md
@@ -49,7 +49,7 @@ LOG_LEVEL_RIVER=DEBUG stellad server
 
 ### OpenTelemetry 模式
 
-设置 `OTEL_EXPORTER_OTLP_ENDPOINT` 会同时启用追踪、日志和指标；也可以用信号专用导出器变量只启用部分信号。指标覆盖 HTTP 服务器（请求数、耗时）和 Go 运行时（内存、GC、goroutine）。如果后端不支持日志服务（如 Jaeger），Stella 会在首次失败后自动禁用日志导出。Stella 将导出器配置交给 OpenTelemetry SDK，因此支持标准的 OTel 环境变量：
+设置 `OTEL_EXPORTER_OTLP_ENDPOINT` 会同时启用追踪、日志和指标；也可以用信号专用导出器变量只启用部分信号。指标覆盖 HTTP 服务器（请求数、耗时）、Go 运行时（内存、GC、goroutine）以及下方列出的领域指标。如果后端不支持日志服务（如 Jaeger），Stella 会在首次失败后自动禁用日志导出。Stella 将导出器配置交给 OpenTelemetry SDK，因此支持标准的 OTel 环境变量：
 
 | 环境变量                             | 默认值              | 说明                                                                                                                                                                            |
 | ------------------------------------ | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -61,14 +61,42 @@ LOG_LEVEL_RIVER=DEBUG stellad server
 | `OTEL_EXPORTER_OTLP_TRACES_HEADERS`  | _(空)_              | 仅应用于 traces 的逗号分隔请求头。会覆盖针对 traces 的通用 OTLP 请求头。                                                                                                        |
 | `OTEL_EXPORTER_OTLP_LOGS_HEADERS`    | _(空)_              | 仅应用于 logs 的逗号分隔请求头。会覆盖针对 logs 的通用 OTLP 请求头。                                                                                                            |
 | `OTEL_TRACES_EXPORTER`               | SDK 默认            | Trace 导出器。设为 `none` 可只关闭 trace 导出，保留其他 OTel 信号。                                                                                                             |
+| `OTEL_TRACES_SAMPLER`                | SDK 默认            | Trace 采样策略，例如 `parentbased_traceidratio`。                                                                                                                               |
+| `OTEL_TRACES_SAMPLER_ARG`            | SDK 默认            | 采样参数，例如 `0.1` 表示 10% trace 比例采样。                                                                                                                                  |
 | `OTEL_LOGS_EXPORTER`                 | SDK 默认            | Log 导出器。设为 `none` 可只关闭 log 导出，保留 trace。                                                                                                                         |
 | `OTEL_METRICS_EXPORTER`              | SDK 默认            | 指标导出器。设为 `none` 可只关闭指标导出，保留其他 OTel 信号。                                                                                                                  |
 | `OTEL_SERVICE_NAME`                  | `stella`            | 在可观测性后端显示的服务名。                                                                                                                                                    |
 | `OTEL_RESOURCE_ATTRIBUTES`           | _(空)_              | 附加到所有信号的资源属性，例如 `deployment.environment=prod`。                                                                                                                  |
 | `OTEL_EXPORTER_OTLP_INSECURE`        | SDK 默认            | 设为 `false` 以要求 TLS。HTTPS 或安全 gRPC 端点请使用 `false`。                                                                                                                 |
+| `OTEL_STELLA_RECORD_DB_QUERIES`      | `false`             | 设为 `true` 才启用 PostgreSQL 逐查询 client span。默认关闭，因为查询 span 数量多且包含 `db.statement`。                                                                         |
 | `OTEL_STELLA_RECORD_TOOL_IO`         | `false`             | 设为 `true` 才会把工具输入(如 bash 命令)和结果文本记录到 span。默认关闭,因此这些内容永不导出;span 始终携带工具名、参数数量与结果长度。                                          |
 
-启用 OTel 后，两种模式会同时运行——你既能看到 stderr 日志行，也能导出追踪、日志和指标。处于追踪路径上的日志行（LLM 调用、工具调用、HTTP 请求）会携带 `trace_id` 和 `span_id`，可以直接从 stderr 行跳到后端里对应的 trace。
+启用 OTel 后，两种模式会同时运行——你既能看到 stderr 日志行，也能导出追踪、日志和指标。处于追踪路径上的日志行（LLM 调用、工具调用、HTTP 请求），只要上下文带有 span，就会携带 `trace_id` 和 `span_id`，可以直接从 stderr 行跳到后端里对应的 trace。导出日志和 stderr 使用同一个 tee handler。
+
+### 领域指标
+
+启用指标导出后，Stella 从同一组 agent-loop hook payload 记录以下领域指标。耗时单位是秒；token 和计数指标使用表中单位。任何指标都不会把 `session_id`、`user_id`、调用 ID、URL、参数、结果或错误消息作为 label。
+
+| 指标                             | 类型/单位            | Labels                                                                                               |
+| -------------------------------- | -------------------- | ---------------------------------------------------------------------------------------------------- |
+| `stella.llm.call.duration`       | histogram，s         | `model`、`provider`、`agent_id`、`channel`                                                           |
+| `stella.llm.time_to_first_token` | histogram，s         | `model`、`provider`、`agent_id`、`channel`                                                           |
+| `stella.llm.tokens`              | counter，token       | `model`、`provider`、`type`（`input`、`output`、`cache_read`、`cache_write`）、`agent_id`、`channel` |
+| `stella.llm.cost`                | counter，USD         | `model`、`provider`、`agent_id`、`channel`                                                           |
+| `stella.llm.calls`               | counter，call        | `model`、`provider`、`stop_reason`、`error.type`、`agent_id`、`channel`                              |
+| `stella.llm.attempts`            | counter，attempt     | `model`、`provider`、`agent_id`、`channel`                                                           |
+| `stella.tool.call.duration`      | histogram，s         | `tool`、`is_error`、`error_kind`、`agent_id`、`channel`                                              |
+| `stella.tool.calls`              | counter，call        | `tool`、`is_error`、`error_kind`、`agent_id`、`channel`                                              |
+| `stella.agent.turn.duration`     | histogram，s         | `agent_id`、`channel`                                                                                |
+| `stella.agent.turns`             | counter，turn        | `agent_id`、`channel`、`error.type`                                                                  |
+| `stella.memory.op.duration`      | histogram，s         | `op`、`agent_id`、`channel`                                                                          |
+| `stella.llm_usage.queue.dropped` | counter，observation | 无                                                                                                   |
+| `stella.llm_usage.queue.depth`   | gauge，observation   | 无                                                                                                   |
+| `stella.trace.sessions.active`   | gauge，session       | 无                                                                                                   |
+
+在开发环境中，请在 `~/.stella-dev/.env` 设置 `OTEL_METRICS_EXPORTER=otlp` 以导出这些指标。`stella` 不会修改该文件。
+
+`model`、`provider`、`tool`、`channel`、`op`、`error_kind` 和 `stop_reason` 是有界的运维维度。`channel` 使用 `web`、`telegram`、`feishu`、`discord`、`qq`、`wechat`、`scheduler`、`goal` 等传输名称。
 
 ### 常见陷阱
 
@@ -240,19 +268,17 @@ Web UI 与 API 的入站请求会记录为 `http.server` span，让你可以端�
 Span 按每个对话会话组织成层级结构：
 
 ```
-chat
-  └── turn 1
-       ├── gen_ai.chat                 3.2s
-       │    └── gen_ai.chat.request    0.4s
-       ├── gen_ai.execute_tool (bash)  1.5s
-       ├── gen_ai.execute_tool (bash)  0.1s
-       └── memory.append               0.02s
-  └── turn 2
-       ├── gen_ai.chat                 2.8s
-       └── memory.compact              0.2s
+channel.ingress / scheduler.job / goal.attempt
+  └── agent.loop
+       └── agent.turn
+            ├── gen_ai.chat             3.2s
+            │    └── gen_ai.chat.request 0.4s
+            ├── gen_ai.execute_tool    1.5s
+            │    └── gen_ai.execute_tool（子调用）
+            └── memory.append           0.02s
 ```
 
-每次 stella 调用 LLM 都会开始一个新的 **turn**。**chat** 根 span 覆盖整个对话，在 2 分钟无活动后关闭。
+每次 stella 调用 LLM 都会开始一个新的 **agent.turn**。`agent.loop` 组织一个会话的活动，在 2 分钟无活动后关闭。非 HTTP 入口使用 `channel.ingress`、`scheduler.job` 或 `goal.attempt` 作为根 span。
 
 ## Span 属性参考
 
@@ -276,8 +302,8 @@ LLM 与工具 span 遵循 [OpenTelemetry GenAI 语义约定](https://opentelemet
 | `gen_ai.server.time_to_first_token`        | chat         | TTFT（秒）                       |
 | `gen_ai.tool.name`                         | execute_tool | 工具名                           |
 | `gen_ai.tool.call.id`                      | execute_tool | 工具调用 ID                      |
-| `gen_ai.tool.error_kind`                   | execute_tool | `tool_error` / `command_nonzero` |
-| `gen_ai.tool.exit_code`                    | execute_tool | 命令退出码                       |
+| `stella.tool.error_kind`                   | execute_tool | `tool_error` / `command_nonzero` |
+| `stella.tool.exit_code`                    | execute_tool | 命令退出码                       |
 | `error.type`                               | 全部         | 失败时的错误类型                 |
 
 记忆 span 使用 stella 特定属性：


### PR DESCRIPTION
## What

Repair the agent-loop OpenTelemetry pipeline and close the full review follow-up: exporter lifecycle, safe log routing, truthful span hierarchy, Code Mode child tracing, ingress context, domain metrics, and observability documentation.

## Why

The first implementation fixed the main pipeline defects but review found remaining raw error values on the OTLP log leg, a durable-channel overwrite risk, missing Web telemetry metadata, prematurely ended turn spans, incomplete queue/admission coverage, uninstrumented forged tools, stale GenAI attribute names, and an OTLP log level mismatch.

## How

- `11843257d` established the pipeline repair and domain metrichook.
- `22d156958` canonicalized the WeChat transport label.
- `39a5edb0c` closes review items F1-F18. `16e156402` closes F19 by tracking each turn's active tool spans and ending the turn at its actual work boundary:
  - console-only raw error diagnostics with safe `error.type` and closed classes on the OTLP leg;
  - durable conversation channel preservation and explicit Web transport metadata;
  - turn spans kept open through tool execution and linked to ingress context;
  - queue/admission timing, tool-parented memory spans, lock-safe active operation tracking, and scheduler/goal context propagation;
  - forged-tool hook envelopes with stable `<unknown>` metric labels;
  - aggregation-key span names `chat {model}` and `execute_tool {tool}`;
  - provider tool attributes under `stella.llm.*`;
  - metric value/cardinality assertions, level-filtered OTLP logs, rate-limited OTel SDK warnings, and synchronized EN/ZH docs.

## Test

- `mise run format && mise run build && mise run test` passed after F19.
- Focused in-process tests cover F1-F18, including OTLP log privacy and level filtering, durable channel preservation, provider tool truth, Code Mode span/audit nesting, ingress queue timing, memory parentage, forged tools, metrics values and labels, query-span opt-in, scheduler/goal context propagation, and startup wiring.
- Live scratch check completed without touching the user's dev server on port 25678 or editing `~/.stella-dev/.env`. It used a fresh embedded-DB `stellad` on port 25912, a deterministic fake provider, and LGTM at `http://localhost:13413`:
  - Session `01a04e7f-e397-7436-893c-876be4718aed`: Loki 25 records versus stderr 25 records.
  - Tempo trace `ae5ff83c5092af274f1d400d709e2607`: HTTP ingress/admission, `agent.runner_get_or_create`, `agent.loop`, two `agent.turn` spans, two `chat live-model` spans, `execute_tool code`, and two nested `execute_tool bash` child spans; the first `agent.turn` ended at `1788024327493248459`, after its last child ended at `1788024327492917708`, and before turn 2 started at `1788024327493278000`. The provider-facing attribute was `stella.llm.provider_tool_count=1`, names `[code]`, with `stella.code.catalog_size=50`; the code span carried child_count=2, child_error_count=0, and a closed failure class.
  - Prometheus/Mimir queries showed `stella_llm_calls_total` and `stella_tool_calls_total`; `stella_llm_call_duration_seconds_count` included the `error_type` label, for example `error_type="none"` with count 2 for the live agent.
- No agent behavior change: existing tool visibility and Code Mode execution semantics are preserved; this PR changes only telemetry envelopes, context propagation, metrics, and safe diagnostics. Harbor eval is not applicable.

## Refs

Closes #1187

## Checklist

- [x] The PR links GitHub issue #1187; delivered by `11843257d`, `22d156958`, `39a5edb0c`, and final review follow-up `16e156402`.
- [x] Focused in-process tests were added or updated for every changed non-trivial behavior, including the metric cardinality/value guard.
- [x] English and Chinese observability documentation was updated and re-read against the final code, including metrics, guest-session privacy, query-span opt-in, provider tool attributes, and aggregation-key span names. `~/.stella-dev/.env` was not edited.
- [x] `mise run format && mise run build && mise run test` passed.
- [x] Harbor eval is not applicable because there is no agent-behavior change.
- [x] No eval-only surface is changed. Code Mode telemetry is covered by in-process runner and trace-recorder tests; no pixel, document, CRLF, non-UTF-8, or binary behavior changed.
- [x] Earlier observability review measurements remain superseded by this fix and are retained in issue #1187.

## Feishu Task

- [修复 Agent Loop 可观测性管线](https://mcnnox2fhjfq.feishu.cn/record/QIwirGGP0eRRS8c64bJcM0Xsnaf) (#1187)
