### PR TITLE
🐛 release: fix clean checkout runtime generation

### DIFF
--- a/internal/cmd/syncembeddedbinaries/main.go
+++ b/internal/cmd/syncembeddedbinaries/main.go
@@ -8,7 +8,8 @@
 //
 //	TARGET_GOOS=<os> TARGET_GOARCH=<arch> go run ./internal/cmd/syncembeddedbinaries
 //
-// Defaults to the current runtime platform when the target is unset.
+// Syncs all supported embedded platforms when no target is set, or one target
+// when TARGET_GOOS and TARGET_GOARCH are provided.
 package main
 
 import (
@@ -71,14 +72,32 @@ var xbergAssets = map[string]xbergAsset{
 // `go run ./internal/cmd/...` sets as the working directory.
 const outputRoot = "resources/binaries/binaries"
 
+var embeddedPlatforms = []string{
+	"darwin-amd64",
+	"darwin-arm64",
+	"linux-amd64",
+	"linux-arm64",
+	"windows-amd64",
+	"windows-arm64",
+}
+
 func main() {
-	goos := os.Getenv("TARGET_GOOS")
-	goarch := os.Getenv("TARGET_GOARCH")
+	targetGOOS := os.Getenv("TARGET_GOOS")
+	targetGOARCH := os.Getenv("TARGET_GOARCH")
+	goos := targetGOOS
+	goarch := targetGOARCH
 	if goos == "" {
 		goos = os.Getenv("GOOS")
 	}
 	if goarch == "" {
 		goarch = os.Getenv("GOARCH")
+	}
+	if targetGOOS == "" && targetGOARCH == "" && goos == "" && goarch == "" {
+		for _, platform := range embeddedPlatforms {
+			parts := strings.SplitN(platform, "-", 2)
+			syncPlatform(parts[0], parts[1])
+		}
+		return
 	}
 	if goos == "" {
 		goos = runtime.GOOS
@@ -86,8 +105,11 @@ func main() {
 	if goarch == "" {
 		goarch = runtime.GOARCH
 	}
-	platform := goos + "-" + goarch
+	syncPlatform(goos, goarch)
+}
 
+func syncPlatform(goos, goarch string) {
+	platform := goos + "-" + goarch
 	if _, ok := miseAssets[platform]; !ok {
 		fatalf("unsupported platform: %s", platform)
 	}


### PR DESCRIPTION
## What

Fix release builds on clean CI checkouts by generating embedded runtime archives for every supported target platform when no target is specified.

## Why

The first `v0.66.0-rc.1` release run passed source, quality, test, and system gates but its release snapshot failed because the generator only created the host platform's archives. GoReleaser then could not compile the Darwin targets from a Linux runner.

## How

- Sync Darwin, Linux, and Windows amd64/arm64 runtime assets by default.
- Preserve targeted generation when `TARGET_GOOS` and `TARGET_GOARCH` are provided.

## Test

- `go run ./internal/cmd/syncembeddedbinaries`
- `mise run format`
- `mise run build`
- `mise run test`

## Refs

No issue: release-blocking CI fix for v0.66.0-rc.1.

## Checklist

- [x] The PR links a GitHub issue, or states why the fix is small enough not to need one.
- [x] I added or updated focused tests for changed non-trivial behavior, or explained why none are needed.
- [x] I updated relevant English and Chinese documentation, or no documentation change is needed.
- [x] I ran `mise run format && mise run build && mise run test`.
- [x] If this changes agent behavior (tools, prompts, the runner loop): Not applicable, this changes release asset generation only.
- [x] If the change touches a surface no eval task exercises (pixel understanding, document extraction, CRLF fidelity, non-UTF-8, binary handling): Not applicable, this changes release asset generation only.
- [x] Any earlier measurement this PR invalidates is marked superseded with its reason, not deleted.
