### PR TITLE
🐛 release: prepare host assets for cross builds

### DIFF
--- a/internal/cmd/syncembeddedbinaries/main.go
+++ b/internal/cmd/syncembeddedbinaries/main.go
@@ -106,6 +106,9 @@ func main() {
 		goarch = runtime.GOARCH
 	}
 	syncPlatform(goos, goarch)
+	if goos != runtime.GOOS || goarch != runtime.GOARCH {
+		syncPlatform(runtime.GOOS, runtime.GOARCH)
+	}
 }
 
 func syncPlatform(goos, goarch string) {


### PR DESCRIPTION
## What

Fix cross-compiling Docker builds by generating the host platform's embedded runtime assets before building a requested target platform.

## Why

The previous release run generated only `linux-arm64` inside the arm64 Docker build. The generator then compiled a host `linux-amd64` helper package and failed because `binaries/linux-amd64/mise.gz` was absent.

## How

- Keep targeted generation for `TARGET_GOOS` and `TARGET_GOARCH`.
- Also ensure the generator host platform's assets exist whenever the target differs from the host.

## Test

- `TARGET_GOOS=linux TARGET_GOARCH=arm64 go run ./internal/cmd/syncembeddedbinaries`
- `mise run format`
- `mise run build`
- `mise run test`

## Refs

No issue: release-blocking CI fix for v0.66.0-rc.1.

## Checklist

- [x] The PR links a GitHub issue, or states why the fix is small enough not to need one.
- [x] I added or updated focused tests for changed non-trivial behavior, or explained why none are needed.
- [x] I updated relevant English and Chinese documentation, or no documentation change is needed.
- [x] I ran `mise run format && mise run build && mise run test`.
- [x] If this changes agent behavior (tools, prompts, the runner loop): Not applicable, this changes release asset generation only.
- [x] If the change touches a surface no eval task exercises (pixel understanding, document extraction, CRLF fidelity, non-UTF-8, binary handling): Not applicable, this changes release asset generation only.
- [x] Any earlier measurement this PR invalidates is marked superseded with its reason, not deleted.
