### PR TITLE
🔧 evals: add a one-command report task

### DIFF
--- a/.mise/tasks/eval/report
+++ b/.mise/tasks/eval/report
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+#MISE description="Render a Harbor job or archived release as CSV results plus an HTML view"
+set -euo pipefail
+
+# Reading a past run took three manual steps that are easy to get wrong: untar
+# the archive, notice whether it holds one job or several, and merge the several
+# with the documented k-per-task rule before any number means anything. Getting
+# that wrong produces a plausible score rather than an error, so it lives here
+# instead of in everyone's shell history.
+
+usage() {
+  cat >&2 <<'USAGE'
+usage: mise run eval:report -- <job-dir|results.tgz> [options]
+
+  -o DIR         where to write (default dist/evals/report/<name>)
+  -k N           trials per task when the source needs merging (default 5)
+  --baseline A   draw agent A's latest release as a reference line, e.g. --baseline Pi
+  --peers        list non-Stella runs in the release table
+  --detail       inline every trial's ledger; makes the HTML megabytes
+
+Writes trials.csv and tasks.csv, the results worth keeping, and report.html,
+a view to regenerate rather than archive.
+USAGE
+  exit 2
+}
+
+[ $# -ge 1 ] || usage
+case $1 in -h|--help) usage ;; esac
+source_arg=$1
+shift
+
+out_dir=""
+k=5
+render_args=""
+while [ $# -gt 0 ]; do
+  case $1 in
+    -o) [ $# -ge 2 ] || usage; out_dir=$2; shift 2 ;;
+    -k) [ $# -ge 2 ] || usage; k=$2; shift 2 ;;
+    --baseline) [ $# -ge 2 ] || usage; render_args="$render_args --baseline $2"; shift 2 ;;
+    --peers|--detail) render_args="$render_args $1"; shift ;;
+    -h|--help) usage ;;
+    *) echo "eval:report: unknown option $1" >&2; usage ;;
+  esac
+done
+
+[ -e "$source_arg" ] || { echo "eval:report: no such path: $source_arg" >&2; exit 1; }
+
+# An archive is named for its contents ("results-redacted.tgz"), which says
+# nothing; the directory holding it is the release, which says everything.
+if [ -f "$source_arg" ]; then
+  name=$(basename "$(dirname "$source_arg")")
+else
+  name=$(basename "$source_arg")
+fi
+: "${out_dir:=dist/evals/report/$name}"
+
+work=$(mktemp -d "${TMPDIR:-/tmp}/eval-report.XXXXXX")
+trap 'rm -rf "$work"' EXIT
+
+job=$source_arg
+if [ -f "$source_arg" ]; then
+  echo "eval:report: extracting $source_arg"
+  mkdir -p "$work/extracted"
+  tar xzf "$source_arg" -C "$work/extracted"
+  job=$work/extracted
+fi
+
+# A renderable job holds <run>/<trial>/result.json. One level deeper means the
+# archive kept several jobs side by side, and those must go through the merge
+# rule before they are one measurement rather than a pile of attempts.
+# `|| true` because head closes the pipe on the first hit and pipefail would
+# report that SIGPIPE as a failure; an empty result is the real error case and
+# is checked on the next line.
+trial_result=$(find "$job" -maxdepth 5 -name result.json -not -path '*/agent/*' -print 2>/dev/null | head -n 1 || true)
+[ -n "$trial_result" ] || { echo "eval:report: found no trials under $job" >&2; exit 1; }
+relative=${trial_result#"$job"/}
+depth=$(printf '%s' "$relative" | tr -cd '/' | wc -c | tr -d ' ')
+
+if [ "$depth" -ge 3 ]; then
+  echo "eval:report: several jobs here; selecting the first $k valid trials per task"
+  python3 - "$job" "$work/merged" "$k" <<'PY'
+import sys
+from pathlib import Path
+
+sys.path.insert(0, "test/evals/harbor")
+from stella_harbor.aws_merge import merge
+
+source, output, k = Path(sys.argv[1]), Path(sys.argv[2]), int(sys.argv[3])
+state = merge(source, output, k)
+print(f"eval:report: merged {state['copied']} trials across {state['tasks']} tasks")
+PY
+  job=$work/merged
+fi
+
+mkdir -p "$out_dir"
+# shellcheck disable=SC2086 # render_args is a deliberately built flag list
+uv run --project test/evals/harbor python -m stella_harbor.report \
+  "$job" --csv "$out_dir" --html "$out_dir/report.html" $render_args

--- a/test/evals/harbor/results/README.md
+++ b/test/evals/harbor/results/README.md
@@ -53,22 +53,29 @@ with the rendered per-trial report in `stella-luna-k5-report.txt`.
 1. Merge the jobs into one directory holding exactly k trials per task, taking
    the first k valid trials in job order, decided before looking at rewards.
 2. Write the results:
-   `python -m stella_harbor.report <merged-dir> --csv <archive-dir>`. That is
-   `trials.csv` and `tasks.csv`, raw values in the units the harness measured,
-   and it is the form worth keeping: it diffs in review, opens in a
-   spreadsheet, and can be recomputed against without this code. An empty cell
-   means the field was never measured, never that it was zero.
+   `mise run eval:report -- <merged-dir> -o <archive-dir>`. That is `trials.csv`
+   and `tasks.csv`, raw values in the units the harness measured, and it is the
+   form worth keeping: it diffs in review, opens in a spreadsheet, and can be
+   recomputed against without this code. An empty cell means the field was
+   never measured, never that it was zero.
 
-   A rendered view is a separate, throwaway step. Add `--html <out>.html` when
-   someone wants to look. It shows this job's headline and then every metric's
-   trend across Stella's archived releases, read from `timeline.csv`, because
-   one number from one run is not something anyone can act on. `--baseline Pi`
-   draws Pi's latest run as a dashed reference line on every metric it measured
-   and states the gap; it is a mark for reading the scale, never a target, and
-   the release decision stays Stella against its own previous release.
-   `--peers` lists every non-Stella run in the release table, and `--detail`
-   inlines the per-trial ledger at the cost of megabytes. Do not archive the HTML: it is one command
-   away from the CSV, and a stale rendering outlives the code that explains it.
+   The task renders `report.html` beside them, and that file is a throwaway
+   view: regenerate it, never archive it, because a stale rendering outlives
+   the code that explains its columns. It shows this job's headline and then
+   every metric's trend across Stella's archived releases, read from
+   `timeline.csv`, because one number from one run is not something anyone can
+   act on. `--baseline Pi` draws Pi's latest run as a dashed reference line on
+   every metric it measured and states the gap; it is a mark for reading the
+   scale, never a target, and the release decision stays Stella against its own
+   previous release. `--peers` lists every non-Stella run in the release table,
+   and `--detail` inlines the per-trial ledger at the cost of megabytes.
+
+   To read a release that is already archived, hand the task its bundle instead
+   of a job directory:
+   `mise run eval:report -- <release>/results-redacted.tgz --baseline Pi`. It
+   unpacks the archive, and when the bundle holds several unmerged jobs it
+   applies the step 1 selection rule before reporting anything, because those
+   attempts are not one measurement until it has.
 3. Create `<benchmark>/<date>-<name>/` with a `README.md` recording dataset
    name and hash, model, k, concurrency, timeout multiplier, host class, the
    result, and every limitation that bounds it.


### PR DESCRIPTION
## What

`mise run eval:report -- <job-dir|results.tgz>` renders a Harbor run: `trials.csv` and `tasks.csv` as the kept results, plus a `report.html` view. It unpacks an archive when given one, and applies the k-per-task selection rule when the bundle holds several unmerged jobs.

## Why

Reading a past run took three manual steps: untar the bundle, notice whether it holds one job or several, and merge the several before any number means anything. The middle step is the trap. Skipping the merge does not fail, it reports a plausible score over 468 attempts instead of 445, so the step easiest to forget is the one that quietly corrupts the answer.

The repository convention is also that workflows run through `mise run`, and this one only existed as a `python -m` line in shell history and a README paragraph.

## How

A file task in `.mise/tasks/eval/report`, since it needs branching rather than a one-liner.

It finds a trial's `result.json` and measures its depth below the source. `<run>/<trial>/result.json` is a renderable job; one level deeper means several jobs sit side by side, and those go through `stella_harbor.aws_merge.merge` first. That is a structural fact about the directory, not a flag anyone has to remember to pass.

Deliberate limits:

- `-k` defaults to 5 and only matters when merging. A bundle needing a different k is stated, not guessed.
- Output defaults to `dist/evals/report/<name>`. For an archive the name comes from its parent directory, because `results-redacted.tgz` names the contents and the directory names the release.
- `--baseline`, `--peers` and `--detail` pass straight through to the renderer; the task adds no reporting behaviour of its own.

## Test

- `mise run format && mise run build && mise run test` ✅
- `mise run lint:shell` ✅ 23 files clean
- Rendered all three source shapes: a plain job directory, the single-job `2026-08-31` bundle, and the three-job `2026-08-20` bundle. The last one merged 445 trials across 89 tasks and reproduced its published 47.4% (211/445) and pass^5 22.5% with no manual step, which is the case the task exists for.
- `--help` and an unknown flag both exit non-zero with usage.

## Refs

No issue: a task wrapper for an existing documented command, added because rendering a release by hand had a silent failure mode.

## Checklist

- [x] The PR links a GitHub issue, or states why the fix is small enough not to need one.
- [x] I added or updated focused tests for changed non-trivial behavior, or explained why none are needed. No automated test: the task is a thin wrapper whose only logic is the depth check, and exercising it needs a multi-gigabyte job fixture. It was verified against all three real bundle shapes above, and the reporting code it calls is covered by the Harbor suite.
- [x] I updated relevant English and Chinese documentation, or no documentation change is needed. `results/README.md` now documents the task for both the fresh-run and archived-release paths. No Chinese counterpart exists for the internal Harbor results archive.
- [x] I ran `mise run format && mise run build && mise run test`.
- [x] If this changes agent behavior (tools, prompts, the runner loop): I included eval evidence with both jobs, commits, tier, k, host, and model, or stated why it is not applicable. Not applicable: this changes how an existing result is rendered and touches no agent code.
- [x] If the change touches a surface no eval task exercises (pixel understanding, document extraction, CRLF fidelity, non-UTF-8, binary handling): I said so, and named the tests that cover it instead. Not applicable: a shell wrapper over an existing reporting command.
- [x] Any earlier measurement this PR invalidates is marked superseded with its reason, not deleted. None invalidated; rendering the archived bundles reproduces their published numbers exactly.
