### PR TITLE
✨ feat(tools): prefix conversational Settings tools

### DIFF
--- a/internal/cmd/syncembeddedbinaries/main.go
+++ b/internal/cmd/syncembeddedbinaries/main.go
@@ -8,7 +8,8 @@
 //
 //	TARGET_GOOS=<os> TARGET_GOARCH=<arch> go run ./internal/cmd/syncembeddedbinaries
 //
-// Defaults to the current runtime platform when the target is unset.
+// Syncs all supported embedded platforms when no target is set, or one target
+// when TARGET_GOOS and TARGET_GOARCH are provided.
 package main
 
 import (
@@ -71,14 +72,32 @@ var xbergAssets = map[string]xbergAsset{
 // `go run ./internal/cmd/...` sets as the working directory.
 const outputRoot = "resources/binaries/binaries"
 
+var embeddedPlatforms = []string{
+	"darwin-amd64",
+	"darwin-arm64",
+	"linux-amd64",
+	"linux-arm64",
+	"windows-amd64",
+	"windows-arm64",
+}
+
 func main() {
-	goos := os.Getenv("TARGET_GOOS")
-	goarch := os.Getenv("TARGET_GOARCH")
+	targetGOOS := os.Getenv("TARGET_GOOS")
+	targetGOARCH := os.Getenv("TARGET_GOARCH")
+	goos := targetGOOS
+	goarch := targetGOARCH
 	if goos == "" {
 		goos = os.Getenv("GOOS")
 	}
 	if goarch == "" {
 		goarch = os.Getenv("GOARCH")
+	}
+	if targetGOOS == "" && targetGOARCH == "" && goos == "" && goarch == "" {
+		for _, platform := range embeddedPlatforms {
+			parts := strings.SplitN(platform, "-", 2)
+			syncPlatform(parts[0], parts[1])
+		}
+		return
 	}
 	if goos == "" {
 		goos = runtime.GOOS
@@ -86,8 +105,11 @@ func main() {
 	if goarch == "" {
 		goarch = runtime.GOARCH
 	}
-	platform := goos + "-" + goarch
+	syncPlatform(goos, goarch)
+}
 
+func syncPlatform(goos, goarch string) {
+	platform := goos + "-" + goarch
 	if _, ok := miseAssets[platform]; !ok {
 		fatalf("unsupported platform: %s", platform)
 	}

--- a/internal/cmd/syncembeddedbinaries/main.go
+++ b/internal/cmd/syncembeddedbinaries/main.go
@@ -106,6 +106,9 @@ func main() {
 		goarch = runtime.GOARCH
 	}
 	syncPlatform(goos, goarch)
+	if goos != runtime.GOOS || goarch != runtime.GOARCH {
+		syncPlatform(runtime.GOOS, runtime.GOARCH)
+	}
 }
 
 func syncPlatform(goos, goarch string) {

--- a/web/content/docs/changelog.mdx
+++ b/web/content/docs/changelog.mdx
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.66.0-rc.1] - 2026-08-31
+
 ### ⚠️ Breaking Changes
 
 - Every built-in tool family is now one tool per action: `goal`, `scheduler`, `workflow`, `oauth`, `email`, `share`, `vault`, `session`, `skills` and `memory` no longer take an `action` argument, and four recally tools were reordered so that all twelve now follow the `<domain>_<resource>_<action>` grammar. The model now sees an exact, sealed schema per call instead of one flat union of every action's fields. `memory_search` also renames the union's `query` argument to `q`. This is a clean break, not a compatibility window: on upgrade, every `tool_override` row naming a retired union or recally name is **deleted**, and those tools go back to their default visibility. If you had switched one off, switch it off again under its new name. Delegate preset `tools:` lists and `excluded_tools` entries keep working when they name a **family** — `scheduler` still selects every `scheduler_job_*`, and `memory` still selects both memory tools — but an entry naming a retired tool now selects nothing and must be rewritten to the new name or the family name. `skills` is the one retired name that is not also a family name: the split singularised it, so rewrite it to `skill`. A custom skill that calls an old name by hand also breaks; grep for all of it:
@@ -39,6 +41,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   | `session`               | `session_list`, `session_get`, `session_create`, `session_send`                                                                                                  |
   | `skills`                | `skill_installed_search`, `skill_load`                                                                                                                           |
   | `memory`                | `memory_search`, `memory_read`                                                                                                                                   |
+
+### ✨ Features
+
+- Add Code Mode for context-efficient tool execution, with strict declarations and an in-process smoke gate covering every built-in tool. ([#1123](https://github.com/CherryHQ/stella/pull/1123), [#1184](https://github.com/CherryHQ/stella/pull/1184))
+- Group images now use canonical media routing, preserving consistent media ownership and delivery across channels. ([#1181](https://github.com/CherryHQ/stella/pull/1181))
+- Provider-level default models can be unified with per-agent model overrides. ([#1167](https://github.com/CherryHQ/stella/pull/1167))
+- Add owner-managed system settings tools for administrative configuration. ([#1189](https://github.com/CherryHQ/stella/pull/1189))
+- Release candidates now publish as GitHub prereleases with versioned Docker and sandbox images, without moving stable aliases or channels. ([#1201](https://github.com/CherryHQ/stella/pull/1201))
+
+### 🐛 Bug Fixes
+
+- Tool visibility now fails closed when it cannot be resolved. ([#1175](https://github.com/CherryHQ/stella/pull/1175))
+- Harden Code Mode orchestration and file data flow across edge cases. ([#1169](https://github.com/CherryHQ/stella/pull/1169))
+- Repair the bundled runtime contract and harden every Xberg call site. ([#1149](https://github.com/CherryHQ/stella/pull/1149))
+- Repair system-test journeys that became flaky under Code Mode and per-media baselines. ([#1186](https://github.com/CherryHQ/stella/pull/1186))
+
+### ♻️ Refactoring
+
+- Session media now uses one baseline per media object, with owner purge, orphan sweeping, and tool cleanup. ([#1183](https://github.com/CherryHQ/stella/pull/1183))
+- Unify Library routing and profile UI, and route image inspection through `view_image`. ([#1164](https://github.com/CherryHQ/stella/pull/1164), [#1160](https://github.com/CherryHQ/stella/pull/1160))
+
+### 📡 Observability
+
+- Repair the agent-loop telemetry pipeline across traces, logs, metrics, and hooks. ([#1188](https://github.com/CherryHQ/stella/pull/1188))
+
+### 🔧 CI
+
+- Move script-bodied mise tasks into checked shell scripts, tighten web linting, and make release builds produce complete stamped binaries. ([#1153](https://github.com/CherryHQ/stella/pull/1153), [#1155](https://github.com/CherryHQ/stella/pull/1155), [#1158](https://github.com/CherryHQ/stella/pull/1158))
+
+### 📝 Documentation
+
+- Update tap-web examples and release/deployment documentation for the RC channel. ([#1174](https://github.com/CherryHQ/stella/pull/1174), [#1201](https://github.com/CherryHQ/stella/pull/1201))
+
+**Full Changelog**: [v0.65.0...v0.66.0-rc.1](https://github.com/CherryHQ/stella/compare/v0.65.0...v0.66.0-rc.1)
 
 ## [0.65.0] - 2026-08-25
 

--- a/web/content/docs/changelog.zh.mdx
+++ b/web/content/docs/changelog.zh.mdx
@@ -11,6 +11,8 @@ icon: History
 
 ## [Unreleased]
 
+## [0.66.0-rc.1] - 2026-08-31
+
 ### ⚠️ 破坏性变更
 
 - 所有内置工具家族改为一个 action 一个工具：`goal`、`scheduler`、`workflow`、`oauth`、`email`、`share`、`vault`、`session`、`skills`、`memory` 不再接受 `action` 参数，recally 有 4 个工具重排了名字，12 个工具现在统一遵循 `<domain>_<resource>_<action>` 命名语法。模型看到的是每次调用一份精确、封闭的 schema，而不是把所有 action 字段摊平在一起的 union。`memory_search` 还把 union 的 `query` 参数改名为 `q`。这是一次干净断裂，没有兼容期：升级时所有指向退休 union 名或退休 recally 名的 `tool_override` 行会被**删除**，对应工具恢复默认可见性。如果你之前关掉过某个能力，请用新名字重新关掉。Delegate preset 的 `tools:` 与 `excluded_tools` 写**家族名**时仍然有效——`scheduler` 依然选中全部 `scheduler_job_*`，`memory` 依然选中两个 memory 工具——但写退休工具名的条目现在选不中任何东西，必须改成新名字或家族名。`skills` 是唯一一个本身不是家族名的退休名：拆分后家族名变成单数，请改写为 `skill`。手写调用旧名字的自定义 Skill 同样会失效，用下面的命令一并自查：
@@ -39,6 +41,40 @@ icon: History
   | `session`               | `session_list`、`session_get`、`session_create`、`session_send`                                                                                                  |
   | `skills`                | `skill_installed_search`、`skill_load`                                                                                                                           |
   | `memory`                | `memory_search`、`memory_read`                                                                                                                                   |
+
+### ✨ 功能
+
+- 新增 Code Mode，以更高效地执行工具调用，并通过进程内 smoke gate 覆盖每个内置工具。([#1123](https://github.com/CherryHQ/stella/pull/1123), [#1184](https://github.com/CherryHQ/stella/pull/1184))
+- 群聊图片现在通过统一的 canonical media 路由，确保不同 channel 的媒体归属和投递行为一致。([#1181](https://github.com/CherryHQ/stella/pull/1181))
+- 统一 provider 级默认模型与 Agent 级模型覆盖配置。([#1167](https://github.com/CherryHQ/stella/pull/1167))
+- 新增由 owner 管理的系统设置工具，用于管理配置。([#1189](https://github.com/CherryHQ/stella/pull/1189))
+- Release Candidate 现在以 GitHub prerelease 和带完整版本号的 Docker、sandbox 镜像发布，不会移动 Stable 别名或渠道。([#1201](https://github.com/CherryHQ/stella/pull/1201))
+
+### 🐛 修复
+
+- 工具可见性无法解析时现在默认拒绝，而不是放行。([#1175](https://github.com/CherryHQ/stella/pull/1175))
+- 加固 Code Mode 编排和文件数据流在边界场景下的行为。([#1169](https://github.com/CherryHQ/stella/pull/1169))
+- 修复内置 runtime 契约，并加固所有 Xberg 调用点。([#1149](https://github.com/CherryHQ/stella/pull/1149))
+- 修复 Code Mode 和按媒体基线变更后出现问题的 system-test journey。([#1186](https://github.com/CherryHQ/stella/pull/1186))
+
+### ♻️ 重构
+
+- session media 现在每个媒体对象使用一个基线，并增加 owner purge、孤儿清理和工具清理。([#1183](https://github.com/CherryHQ/stella/pull/1183))
+- 统一 Library 路由与 profile UI，并让图片检查通过 `view_image` 路由。([#1164](https://github.com/CherryHQ/stella/pull/1164), [#1160](https://github.com/CherryHQ/stella/pull/1160))
+
+### 📡 可观测性
+
+- 修复 agent loop 在 trace、log、metric 和 hook 之间的 telemetry pipeline。([#1188](https://github.com/CherryHQ/stella/pull/1188))
+
+### 🔧 CI
+
+- 将脚本型 mise task 移入受检查的 shell 脚本，收紧 web lint，并让 release build 产出完整且带版本信息的二进制文件。([#1153](https://github.com/CherryHQ/stella/pull/1153), [#1155](https://github.com/CherryHQ/stella/pull/1155), [#1158](https://github.com/CherryHQ/stella/pull/1158))
+
+### 📝 文档
+
+- 更新 tap-web 示例，并补充 RC 渠道的发布与部署文档。([#1174](https://github.com/CherryHQ/stella/pull/1174), [#1201](https://github.com/CherryHQ/stella/pull/1201))
+
+**完整变更记录**：[v0.65.0...v0.66.0-rc.1](https://github.com/CherryHQ/stella/compare/v0.65.0...v0.66.0-rc.1)
 
 ## [0.65.0] - 2026-08-25
 

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.65.0",
+  "version": "0.66.0-rc.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## What

Rename all 34 conversational Settings tools into the `settings_` namespace, including API declarations, generated Go types and dispatchers, runtime registration, metadata, tests, and documentation. Enable this Settings surface by default for the built-in Agent whose reserved ID is `stella`; other Agents remain default-off.

## Why

Settings tools are model-facing public API, but their old names were indistinguishable from ordinary tools. This breaking rename makes the boundary explicit and prevents future naming collisions. Built-in Stella is the deployment's default assistant, so it should expose the conversational Settings surface without requiring an extra setup step.

## How

The change renames nine generated Settings families: Agent, Agent tool, Library, Skill, Provider, Default model, Embedding setting, Plugin, and MCP. Ordinary runtime tools such as `library_search`, `skill_load`, and `skill_installed_search` remain unchanged.

This is a clean break with no compatibility aliases. Migration `90000000000032` deletes `tool_override` rows keyed by the 34 retired names, because their old enabled/disabled intent cannot be safely inferred for the replacement names. The down migration is intentionally a no-op.

Fresh installations seed `cfgstore.DefaultStellaAgentID` (`stella`) with Settings tools enabled. Migration `90000000000033` also enables that reserved Agent once on upgrade; managers can turn it off again afterward, and no other Agent is changed. The system prompt restricts `settings_*` use to explicit requests from the signed-in user. Per-action schemas, Settings policy, authorization checks, and foreground-session restrictions are preserved.

## Test

- `mise run format && mise run build && mise run test`
- `mise run db:validate`
- `mise run generate:check`
- Focused Go tests for Agent, Skills, Control Plane, Library, MCP, migrations, prompt size, and `cmd/stellad`
- Migration tests covering deletion of exactly the 34 retired override names, preservation of unrelated/new names, and enabling only the reserved `stella` Agent
- Previous-GA forward migration verifies the built-in Stella policy after upgrade
- Web suite: 33 files, 299 tests passed
- Harbor eval: not applicable. This changes tool names and default discovery for the built-in Stella Agent; action schemas, authorization, and runtime behavior are unchanged, and the benchmark does not exercise this Settings-management surface.
- No pixel/document/CRLF/non-UTF-8/binary surface changed.

## Refs

No issue: the user explicitly requested a direct PR for this breaking rename and built-in Stella default; the complete scope is reviewable from the API, generated-code, migrations, tests, prompt, and documentation diff.

## Checklist

- [x] No GitHub issue is linked because the user explicitly requested a direct PR; rationale is in Refs.
- [x] I added or updated focused tests for changed non-trivial behavior, including both migrations and the generated-tool inventory.
- [x] I updated relevant English and Chinese documentation.
- [x] I ran `mise run format && mise run build && mise run test`.
- [x] This does not change agent behavior beyond the deliberate model-facing tool-name break and built-in Stella discovery default; Harbor eval is not applicable as explained above.
- [x] No eval-only surface such as pixel understanding, document extraction, CRLF fidelity, non-UTF-8, or binary handling is touched.
- [x] No earlier measurement is invalidated.
