### PR TITLE
🐛 fix(web): share React runtime with Base UI

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -68,10 +68,16 @@ export default defineConfig({
     chunkSizeWarningLimit: 800,
   },
   resolve: {
+    // Rolldown's dependency optimizer bundles Base UI's peer React into every
+    // optimized deep import. Leave Base UI as ESM so its hooks use the app's React.
+    dedupe: ["react", "react-dom"],
     alias: {
       "@": path.resolve(import.meta.dirname, "src"),
       "node:path": "pathe",
     },
+  },
+  optimizeDeps: {
+    exclude: ["@base-ui/react"],
   },
   server: {
     port: 25688,

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -68,16 +68,12 @@ export default defineConfig({
     chunkSizeWarningLimit: 800,
   },
   resolve: {
-    // Rolldown's dependency optimizer bundles Base UI's peer React into every
-    // optimized deep import. Leave Base UI as ESM so its hooks use the app's React.
+    // Base UI's deep imports must resolve React through the app's shared runtime.
     dedupe: ["react", "react-dom"],
     alias: {
       "@": path.resolve(import.meta.dirname, "src"),
       "node:path": "pathe",
     },
-  },
-  optimizeDeps: {
-    exclude: ["@base-ui/react"],
   },
   server: {
     port: 25688,


### PR DESCRIPTION
## What

Ensure all Base UI deep imports use the application's single React and React DOM runtime during Vite development.

## Why

Rolldown could resolve a separate React instance while optimizing `@base-ui/react/combobox`, causing the provider editor to crash with an invalid hook call. Excluding Base UI from optimization is not viable because its CommonJS `use-sync-external-store` shims then lack browser ESM named exports.

## How

Use Vite `resolve.dedupe` for `react` and `react-dom`. This preserves Base UI's dependency transformation while making its hooks share the React runtime used by React DOM.

## Test

- `mise run format && mise run build && mise run test` passed.
- Inspected the Vite dependency graph: the app module and optimized Base UI Combobox both import the same Vite React chunk.

## Refs

No issue: self-contained one-file development-runtime bug fix.

## Checklist

- [x] The PR links a GitHub issue, or states why the fix is small enough not to need one.
- [x] I added or updated focused tests for changed non-trivial behavior, or explained why none are needed.
  No focused automated test exists for Vite's emitted dev-module graph; it was inspected directly.
- [x] I updated relevant English and Chinese documentation, or no documentation change is needed.
  No documentation change is needed for an internal development-server resolution fix.
- [x] I ran `mise run format && mise run build && mise run test`.
- [x] If this changes agent behavior (tools, prompts, the runner loop): I included eval evidence with both jobs, commits, tier, k, host, and model, or stated why it is not applicable. See `test/evals/harbor/README.md`.
  Not applicable, this does not change agent behavior.
- [x] If the change touches a surface no eval task exercises (pixel understanding, document extraction, CRLF fidelity, non-UTF-8, binary handling): I said so, and named the tests that cover it instead.
  Not applicable, this only changes Vite's development dependency resolution.
- [x] Any earlier measurement this PR invalidates is marked superseded with its reason, not deleted.
  Not applicable, no earlier measurement exists.
