### PR TITLE
🐛 fix(sandbox): preserve volume owner identity

### DIFF
--- a/plugins/sandbox/docker/process_user_test.go
+++ b/plugins/sandbox/docker/process_user_test.go
@@ -9,10 +9,23 @@ import (
 )
 
 func TestDockerProcessUser(t *testing.T) {
-	if got := dockerProcessUser(true); got != "0:0" {
-		t.Fatalf("rootless process user = %q, want 0:0", got)
+	currentUser := fmt.Sprintf("%d:%d", os.Geteuid(), os.Getegid())
+	tests := []struct {
+		name     string
+		rootless bool
+		mode     DockerSandboxMode
+		want     string
+	}{
+		{name: "rootless host mount", rootless: true, mode: DockerSandboxModeHost, want: "0:0"},
+		{name: "rootless bind mount", rootless: true, mode: DockerSandboxModeBind, want: "0:0"},
+		{name: "rootless named volume", rootless: true, mode: DockerSandboxModeVolume, want: currentUser},
+		{name: "rootful named volume", mode: DockerSandboxModeVolume, want: currentUser},
 	}
-	if got, want := dockerProcessUser(false), fmt.Sprintf("%d:%d", os.Geteuid(), os.Getegid()); got != want {
-		t.Fatalf("rootful process user = %q, want %q", got, want)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := dockerProcessUser(tt.rootless, tt.mode); got != tt.want {
+				t.Fatalf("dockerProcessUser(%v, %q) = %q, want %q", tt.rootless, tt.mode, got, tt.want)
+			}
+		})
 	}
 }

--- a/plugins/sandbox/docker/process_user_unix.go
+++ b/plugins/sandbox/docker/process_user_unix.go
@@ -7,11 +7,12 @@ import (
 	"os"
 )
 
-// dockerProcessUser renders the ownership model exposed by the daemon. UID 0
-// on a rootless daemon maps to the unprivileged daemon user on the host and is
-// the owner rootless bind mounts expose inside the container.
-func dockerProcessUser(rootless bool) string {
-	if rootless {
+// dockerProcessUser renders the ownership model exposed by the daemon. Rootless
+// bind mounts expose the daemon user's host files as container UID 0. Named
+// volumes are different: stellad and the sandbox share the daemon's UID mapping,
+// so the sandbox must keep stellad's process UID to access its 0700 trees.
+func dockerProcessUser(rootless bool, mode DockerSandboxMode) string {
+	if rootless && mode != DockerSandboxModeVolume {
 		return "0:0"
 	}
 	return fmt.Sprintf("%d:%d", os.Geteuid(), os.Getegid())

--- a/plugins/sandbox/docker/process_user_windows.go
+++ b/plugins/sandbox/docker/process_user_windows.go
@@ -1,4 +1,4 @@
 package docker
 
 // Docker Desktop mediates Windows filesystem ownership; keep the image user.
-func dockerProcessUser(bool) string { return "" }
+func dockerProcessUser(bool, DockerSandboxMode) string { return "" }

--- a/plugins/sandbox/docker/session.go
+++ b/plugins/sandbox/docker/session.go
@@ -255,7 +255,7 @@ func (f *dockerFactory) CreateSession(ctx context.Context, policy sandboxpkg.Pol
 	opts := dockerclient.CreateOptions{
 		Image:          f.cfg.Image,
 		Runtime:        f.cfg.Runtime,
-		User:           dockerProcessUser(security.Rootless),
+		User:           dockerProcessUser(security.Rootless, f.cfg.RuntimeMode),
 		WorkspaceHost:  workspaceHost,
 		WorkspaceMount: workspaceMount,
 		NetworkMode:    networkMode,

--- a/plugins/sandbox/docker/session_lifecycle_test.go
+++ b/plugins/sandbox/docker/session_lifecycle_test.go
@@ -360,7 +360,7 @@ func TestCreateSessionUsesRootfulProcessIdentity(t *testing.T) {
 	if err == nil {
 		t.Fatal("CreateSession succeeded despite container start failure")
 	}
-	if got, want := api.createOpts.Config.User, dockerProcessUser(false); got != want {
+	if got, want := api.createOpts.Config.User, dockerProcessUser(false, DockerSandboxModeHost); got != want {
 		t.Errorf("rootful container user = %q, want %q", got, want)
 	}
 }

--- a/web/content/docs/changelog.mdx
+++ b/web/content/docs/changelog.mdx
@@ -105,6 +105,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The built-in Agent with the reserved ID `stella` now enables conversational Settings tools by default. Migration `90000000000032` also enables them once for an existing built-in Stella Agent; an Agent manager can turn them off again after upgrading. Other Agents remain default-off.
 
+### 🐛 Bug Fixes
+
+- Rootless Docker sandboxes using a named `STELLA_HOME` volume now keep the `stellad` process identity, so principal-owned mise state and cache directories remain writable and built-in tool shims resolve correctly.
+
 ## [0.65.0] - 2026-08-25
 
 ### ⚠️ Breaking Changes

--- a/web/content/docs/changelog.zh.mdx
+++ b/web/content/docs/changelog.zh.mdx
@@ -105,6 +105,10 @@ icon: History
 
 - 保留 ID 为 `stella` 的内置 Agent 现在默认开启对话式 Settings tools。迁移 `90000000000032` 也会为已有的内置 Stella Agent 强制开启一次；升级后 Agent 管理者仍可再次关闭。其他 Agent 继续默认关闭。
 
+### 🐛 修复
+
+- 使用 named `STELLA_HOME` volume 的 rootless Docker 沙箱现在会保持 `stellad` 的进程身份，确保 principal 所有的 mise state 与 cache 目录可写，内置工具 shim 也能正确解析。
+
 ## [0.65.0] - 2026-08-25
 
 ### ⚠️ 重大变更


### PR DESCRIPTION
## What

Preserve the `stellad` process UID/GID for rootless Docker sandboxes that mount `STELLA_HOME` from a named volume. Keep the existing container `0:0` mapping for rootless host and bind mounts.

## Why

In named-volume mode, `stellad` and sandbox containers share the Docker daemon's UID mapping. Principal mise directories are created by `stellad` with mode `0700`, so forcing the sandbox to `0:0` makes `.mise-tools/state`, `.mise-tools/cache`, and seeded installs inaccessible when `stellad` runs as the image's non-root `stella` user.

The resulting sandbox reports repeated `Permission denied` warnings, marks every built-in mise tool as missing, and fails shims such as `tap` with `tap is not a valid shim`.

## How

Make Docker process identity selection depend on both daemon rootlessness and the configured mount mode:

- rootless host/bind mounts continue to use `0:0`, matching the daemon owner's host files;
- rootless named volumes use `stellad`'s effective UID/GID, matching files written into the shared volume;
- rootful Docker continues to use `stellad`'s effective UID/GID.

Add focused coverage for all four identity combinations and update the English and Chinese changelogs.

## Test

- `mise run format && mise run build && mise run test`
- `GOOS=linux GOARCH=amd64 go test -c -o /tmp/stella-sandbox-docker-linux-amd64.test ./plugins/sandbox/docker`
- `GOOS=windows GOARCH=amd64 go test -c -o /tmp/stella-sandbox-docker-windows-amd64.test.exe ./plugins/sandbox/docker`

All passed.

## Refs

No issue: this is a narrowly scoped rootless named-volume ownership regression with a direct failure trace and focused mode-matrix coverage.

## Checklist

- [x] The PR links a GitHub issue, or states why the fix is small enough not to need one.
- [x] I added or updated focused tests for changed non-trivial behavior, or explained why none are needed.
- [x] I updated relevant English and Chinese documentation, or no documentation change is needed.
- [x] I ran `mise run format && mise run build && mise run test`.
- [x] If this changes agent behavior (tools, prompts, the runner loop): not applicable; this corrects Docker filesystem identity selection without changing model-facing behavior.
- [x] If the change touches a surface no eval task exercises: covered by the Docker identity mode-matrix unit test and Linux/Windows cross-compilation; no Harbor task exercises rootless named-volume ownership.
- [x] Any earlier measurement this PR invalidates is marked superseded with its reason, not deleted: not applicable; no measurement is changed.
