### PR TITLE
📝 docs: prepare v0.66.1 patch release

### DIFF
--- a/deploy/helm/stella/Chart.yaml
+++ b/deploy/helm/stella/Chart.yaml
@@ -3,12 +3,12 @@ name: stella
 description: Stella — a single-tenant, multi-user, multi-agent AI assistant platform. Single-replica production chart.
 type: application
 # Chart version — bump on chart changes, independent of the app version.
-version: 0.1.3
+version: 0.1.4
 # appVersion is metadata noting the Stella release this chart was developed
 # against. It is NOT the default image tag: the chart defaults image.tag to
 # "latest" (see stella.image / values.yaml) so a fresh install tracks the newest
 # published release. Pin image.tag or image.digest for reproducible deploys.
-appVersion: "v0.66.0"
+appVersion: "v0.66.1"
 home: https://stella.cherryin.com
 sources:
   - https://github.com/CherryHQ/stella

--- a/plugins/sandbox/docker/process_user_test.go
+++ b/plugins/sandbox/docker/process_user_test.go
@@ -9,10 +9,23 @@ import (
 )
 
 func TestDockerProcessUser(t *testing.T) {
-	if got := dockerProcessUser(true); got != "0:0" {
-		t.Fatalf("rootless process user = %q, want 0:0", got)
+	currentUser := fmt.Sprintf("%d:%d", os.Geteuid(), os.Getegid())
+	tests := []struct {
+		name     string
+		rootless bool
+		mode     DockerSandboxMode
+		want     string
+	}{
+		{name: "rootless host mount", rootless: true, mode: DockerSandboxModeHost, want: "0:0"},
+		{name: "rootless bind mount", rootless: true, mode: DockerSandboxModeBind, want: "0:0"},
+		{name: "rootless named volume", rootless: true, mode: DockerSandboxModeVolume, want: currentUser},
+		{name: "rootful named volume", mode: DockerSandboxModeVolume, want: currentUser},
 	}
-	if got, want := dockerProcessUser(false), fmt.Sprintf("%d:%d", os.Geteuid(), os.Getegid()); got != want {
-		t.Fatalf("rootful process user = %q, want %q", got, want)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := dockerProcessUser(tt.rootless, tt.mode); got != tt.want {
+				t.Fatalf("dockerProcessUser(%v, %q) = %q, want %q", tt.rootless, tt.mode, got, tt.want)
+			}
+		})
 	}
 }

--- a/plugins/sandbox/docker/process_user_unix.go
+++ b/plugins/sandbox/docker/process_user_unix.go
@@ -7,11 +7,12 @@ import (
 	"os"
 )
 
-// dockerProcessUser renders the ownership model exposed by the daemon. UID 0
-// on a rootless daemon maps to the unprivileged daemon user on the host and is
-// the owner rootless bind mounts expose inside the container.
-func dockerProcessUser(rootless bool) string {
-	if rootless {
+// dockerProcessUser renders the ownership model exposed by the daemon. Rootless
+// bind mounts expose the daemon user's host files as container UID 0. Named
+// volumes are different: stellad and the sandbox share the daemon's UID mapping,
+// so the sandbox must keep stellad's process UID to access its 0700 trees.
+func dockerProcessUser(rootless bool, mode DockerSandboxMode) string {
+	if rootless && mode != DockerSandboxModeVolume {
 		return "0:0"
 	}
 	return fmt.Sprintf("%d:%d", os.Geteuid(), os.Getegid())

--- a/plugins/sandbox/docker/process_user_windows.go
+++ b/plugins/sandbox/docker/process_user_windows.go
@@ -1,4 +1,4 @@
 package docker
 
 // Docker Desktop mediates Windows filesystem ownership; keep the image user.
-func dockerProcessUser(bool) string { return "" }
+func dockerProcessUser(bool, DockerSandboxMode) string { return "" }

--- a/plugins/sandbox/docker/session.go
+++ b/plugins/sandbox/docker/session.go
@@ -255,7 +255,7 @@ func (f *dockerFactory) CreateSession(ctx context.Context, policy sandboxpkg.Pol
 	opts := dockerclient.CreateOptions{
 		Image:          f.cfg.Image,
 		Runtime:        f.cfg.Runtime,
-		User:           dockerProcessUser(security.Rootless),
+		User:           dockerProcessUser(security.Rootless, f.cfg.RuntimeMode),
 		WorkspaceHost:  workspaceHost,
 		WorkspaceMount: workspaceMount,
 		NetworkMode:    networkMode,

--- a/plugins/sandbox/docker/session_lifecycle_test.go
+++ b/plugins/sandbox/docker/session_lifecycle_test.go
@@ -360,7 +360,7 @@ func TestCreateSessionUsesRootfulProcessIdentity(t *testing.T) {
 	if err == nil {
 		t.Fatal("CreateSession succeeded despite container start failure")
 	}
-	if got, want := api.createOpts.Config.User, dockerProcessUser(false); got != want {
+	if got, want := api.createOpts.Config.User, dockerProcessUser(false, DockerSandboxModeHost); got != want {
 		t.Errorf("rootful container user = %q, want %q", got, want)
 	}
 }

--- a/web/content/docs/changelog.mdx
+++ b/web/content/docs/changelog.mdx
@@ -83,6 +83,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **Full Changelog**: [v0.65.0...v0.66.0](https://github.com/CherryHQ/stella/compare/v0.65.0...v0.66.0)
 
+### 🐛 Bug Fixes
+
+- Rootless Docker sandboxes using a named `STELLA_HOME` volume now keep the `stellad` process identity, so principal-owned mise state and cache directories remain writable and built-in tool shims resolve correctly.
+
 ## [0.65.0] - 2026-08-25
 
 ### ⚠️ Breaking Changes

--- a/web/content/docs/changelog.mdx
+++ b/web/content/docs/changelog.mdx
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.66.1] - 2026-09-01
+
+### 🐛 Bug Fixes
+
+- Rootless Docker sandboxes using a named `STELLA_HOME` volume now keep the `stellad` process identity, so principal-owned mise state and cache directories remain writable and built-in tool shims resolve correctly. ([#1214](https://github.com/CherryHQ/stella/pull/1214))
+
+**Full Changelog**: [v0.66.0...v0.66.1](https://github.com/CherryHQ/stella/compare/v0.66.0...v0.66.1)
+
 ## [0.66.0] - 2026-09-01
 
 ### ⚠️ Breaking Changes
@@ -82,10 +90,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update tap-web examples and release/deployment documentation for the RC channel. ([#1174](https://github.com/CherryHQ/stella/pull/1174), [#1201](https://github.com/CherryHQ/stella/pull/1201))
 
 **Full Changelog**: [v0.65.0...v0.66.0](https://github.com/CherryHQ/stella/compare/v0.65.0...v0.66.0)
-
-### 🐛 Bug Fixes
-
-- Rootless Docker sandboxes using a named `STELLA_HOME` volume now keep the `stellad` process identity, so principal-owned mise state and cache directories remain writable and built-in tool shims resolve correctly.
 
 ## [0.65.0] - 2026-08-25
 

--- a/web/content/docs/changelog.zh.mdx
+++ b/web/content/docs/changelog.zh.mdx
@@ -11,6 +11,14 @@ icon: History
 
 ## [Unreleased]
 
+## [0.66.1] - 2026-09-01
+
+### 🐛 修复
+
+- 使用 named `STELLA_HOME` volume 的 rootless Docker 沙箱现在会保持 `stellad` 的进程身份，确保 principal 所有的 mise state 与 cache 目录可写，内置工具 shim 也能正确解析。([#1214](https://github.com/CherryHQ/stella/pull/1214))
+
+**完整变更记录**：[v0.66.0...v0.66.1](https://github.com/CherryHQ/stella/compare/v0.66.0...v0.66.1)
+
 ## [0.66.0] - 2026-09-01
 
 ### ⚠️ 破坏性变更
@@ -82,10 +90,6 @@ icon: History
 - 更新 tap-web 示例，并补充 RC 渠道的发布与部署文档。([#1174](https://github.com/CherryHQ/stella/pull/1174), [#1201](https://github.com/CherryHQ/stella/pull/1201))
 
 **完整变更记录**：[v0.65.0...v0.66.0](https://github.com/CherryHQ/stella/compare/v0.65.0...v0.66.0)
-
-### 🐛 修复
-
-- 使用 named `STELLA_HOME` volume 的 rootless Docker 沙箱现在会保持 `stellad` 的进程身份，确保 principal 所有的 mise state 与 cache 目录可写，内置工具 shim 也能正确解析。
 
 ## [0.65.0] - 2026-08-25
 

--- a/web/content/docs/changelog.zh.mdx
+++ b/web/content/docs/changelog.zh.mdx
@@ -83,6 +83,10 @@ icon: History
 
 **完整变更记录**：[v0.65.0...v0.66.0](https://github.com/CherryHQ/stella/compare/v0.65.0...v0.66.0)
 
+### 🐛 修复
+
+- 使用 named `STELLA_HOME` volume 的 rootless Docker 沙箱现在会保持 `stellad` 的进程身份，确保 principal 所有的 mise state 与 cache 目录可写，内置工具 shim 也能正确解析。
+
 ## [0.65.0] - 2026-08-25
 
 ### ⚠️ 重大变更

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.66.0",
+  "version": "0.66.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## What

Prepare the Stella v0.66.1 stable patch release from `release/v0.66`.

## Why

Ship the rootless named-volume ownership fix and synchronize web/package and Helm release metadata.

## How

- Update the web package version to 0.66.1.
- Update Helm metadata to appVersion v0.66.1 and chart version 0.1.4.
- Record the v0.66.1 changelog in English and Chinese.
- Include the rootless Docker named-volume ownership fix from #1214.

## Test

- `mise run release:validate` passed.
- Working tree clean.

## Refs

No issue: direct release preparation requested by the maintainer.

## Checklist

- [x] The PR links a GitHub issue, or states why the fix is small enough not to need one.
- [x] Focused tests are included in #1214; release metadata has no additional code path.
- [x] English and Chinese changelogs are synchronized.
- [x] `mise run release:validate` passed.
- [x] Agent-behavior eval is not applicable to this Docker ownership fix.
- [x] No eval-only surface is changed.
- [x] No earlier measurement is invalidated.