### PR TITLE
🐛 fix(api): make PATCH /api/agents/{id} a real partial update

### DIFF
--- a/api/spec/domain/agents/paths.yaml
+++ b/api/spec/domain/agents/paths.yaml
@@ -104,6 +104,10 @@ paths:
     patch:
       tags: [agents]
       summary: Update an agent
+      description: >-
+        Partial update. Omitted fields keep their stored value; an explicit
+        empty string clears a text field. id, creator_id, workspace and
+        last_active are server-owned and ignored in the body.
       operationId: updateAgent
       x-agent-tool: {
         tool: "settings_agent",

--- a/internal/server/agent_projection.go
+++ b/internal/server/agent_projection.go
@@ -40,6 +40,44 @@ func agentFromAPI(in apitypes.Agent) config.Agent {
 	return out
 }
 
+// applyAgentPatch merges a PATCH body into the stored Agent. Every body field
+// is a pointer, so omission is distinguishable from an explicit value: omitted
+// fields keep their stored value and an explicit "" clears one. Before this the
+// handler decoded the body into a zero Agent, which turned {"soul": "x"} into a
+// rename-and-disable. Server-owned fields (id, creator, workspace, last_active)
+// are ignored; Management.Update re-asserts them.
+func applyAgentPatch(existing config.Agent, in apitypes.Agent) config.Agent {
+	out := existing
+	setString := func(dst *string, src *string) {
+		if src != nil {
+			*dst = *src
+		}
+	}
+	setString(&out.Name, in.Name)
+	setString(&out.Model, in.Model)
+	setString(&out.ModelThinking, in.ModelThinking)
+	setString(&out.ModelStrong, in.ModelStrong)
+	setString(&out.ModelStrongThinking, in.ModelStrongThinking)
+	setString(&out.ModelFast, in.ModelFast)
+	setString(&out.ModelFastThinking, in.ModelFastThinking)
+	setString(&out.SystemPrompt, in.SystemPrompt)
+	setString(&out.Soul, in.Soul)
+	setString(&out.Scope, in.Scope)
+	if in.Enabled != nil {
+		out.Enabled = *in.Enabled
+	}
+	if in.SystemSettingsToolsEnabled != nil {
+		out.SystemSettingsToolsEnabled = *in.SystemSettingsToolsEnabled
+	}
+	if in.Sandbox != nil && in.Sandbox.Network != nil {
+		setString(&out.Sandbox.Network.Mode, in.Sandbox.Network.Mode)
+		if in.Sandbox.Network.Allowlist != nil {
+			out.Sandbox.Network.Allowlist = append([]string(nil), (*in.Sandbox.Network.Allowlist)...)
+		}
+	}
+	return out
+}
+
 // createAgentFromAPI extracts the sole credential-bearing Agent request into
 // write-only domain inputs. The API DTO is never used as a response projection.
 func createAgentFromAPI(in apitypes.CreateAgentRequest) (config.Agent, string, []providercred.Input) {

--- a/internal/server/agents.go
+++ b/internal/server/agents.go
@@ -206,19 +206,13 @@ func (s *Server) UpdateAgent(w http.ResponseWriter, r *http.Request, id string) 
 		writeError(w, http.StatusBadRequest, "invalid JSON")
 		return
 	}
-	a := agentFromAPI(req)
-	a.ID = id
-	// Agent is currently a broad transport shape, but this policy bit has
-	// security-sensitive default-off semantics. PATCH omission must preserve it;
-	// only a manager's explicit boolean changes discovery of Settings tools.
-	if req.SystemSettingsToolsEnabled == nil {
-		existing, code, msg := s.requireAgentManage(ctx, id)
-		if code != 0 {
-			writeError(w, code, msg)
-			return
-		}
-		a.SystemSettingsToolsEnabled = existing.SystemSettingsToolsEnabled
+	existing, code, msg := s.requireAgentManage(ctx, id)
+	if code != 0 {
+		writeError(w, code, msg)
+		return
 	}
+	a := applyAgentPatch(existing, req)
+	a.ID = id
 	if a.Name == "" {
 		a.Name = id
 	}

--- a/internal/server/agents_test.go
+++ b/internal/server/agents_test.go
@@ -481,3 +481,37 @@ func TestAgentModelRefValidation(t *testing.T) {
 		})
 	}
 }
+
+func TestUpdateAgentIsPartial(t *testing.T) {
+	env := setupAdmin(t)
+
+	agentID := createTestAgent(t, env, config.Agent{
+		Name:    "Partial",
+		Model:   "anthropic/claude-sonnet-4-6",
+		Soul:    "original soul",
+		Scope:   "system",
+		Enabled: true,
+	})
+
+	// A body carrying one field must touch only that field.
+	rr := doRequest(t, env, "PATCH", "/api/agents/"+agentID, map[string]any{"soul": "new soul"})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("soul-only update status = %d (body: %s)", rr.Code, rr.Body.String())
+	}
+	var a config.Agent
+	_ = json.Unmarshal(parseResponse(t, rr).Data, &a)
+	if a.Soul != "new soul" || a.Name != "Partial" || a.Model != "anthropic/claude-sonnet-4-6" || !a.Enabled {
+		t.Fatalf("after soul-only update: name=%q model=%q soul=%q enabled=%v", a.Name, a.Model, a.Soul, a.Enabled)
+	}
+
+	// An explicit empty string still clears.
+	rr = doRequest(t, env, "PATCH", "/api/agents/"+agentID, map[string]any{"model": ""})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("clear-model status = %d (body: %s)", rr.Code, rr.Body.String())
+	}
+	rr = doRequest(t, env, "GET", "/api/agents/"+agentID, nil)
+	_ = json.Unmarshal(parseResponse(t, rr).Data, &a)
+	if a.Model != "" || a.Soul != "new soul" || a.Name != "Partial" {
+		t.Fatalf("after clearing model: name=%q model=%q soul=%q", a.Name, a.Model, a.Soul)
+	}
+}


### PR DESCRIPTION
## What

`PATCH /api/agents/{id}` now merges the request onto the stored agent instead of replacing it: omitted fields keep their value, an explicit `""` clears a text field.

## Why

The handler decoded the body into a zero-valued `config.Agent` and handed the whole struct to `Management.Update`, so `{"soul": "x"}` renamed the agent to its id, cleared its models and prompt, and disabled it. Only `system_settings_tools_enabled` had a preserve-on-omission carve-out. This contradicts the Update contract in `api-design.md` and is a live footgun for any client other than the web form, which happens to send the full object. The model-facing `settings_agent update` tool already merged correctly, so this brings HTTP in line with it.

## How

- `applyAgentPatch(existing, body)` in `internal/server/agent_projection.go`: every generated body field is already a pointer, so presence is detectable without a new request schema. Sandbox network mode and allowlist merge per field the same way.
- `UpdateAgent` always loads the stored agent through `requireAgentManage` (it already did so for the one carved-out field) and merges before validation. The special case is gone.
- The OpenAPI operation gains a `description` stating the partial semantics; no schema change, so generated types are unchanged.
- Deliberate limit: `null` is not treated as "clear" because the `Agent` schema fields are not nullable and the generated pointers cannot distinguish `null` from omission. `""` is the clear signal, which is how the web form already clears a model override.

## Test

- `mise run format && mise run build && mise run test`: passed (full Go suite).
- New `TestUpdateAgentIsPartial` in `internal/server/agents_test.go`: a soul-only PATCH preserves name, model and enabled; a `{"model": ""}` PATCH clears the model and preserves the rest.
- Existing `TestAdminCanUpdateAgentCreatedByAnotherUser` still covers the `system_settings_tools_enabled` preservation now handled by the general merge.
- `mise run system-test`: skipped, no process, auth, or transport seam changed.

## Refs

Closes #1225

## Checklist

- [x] The PR links a GitHub issue, or states why the fix is small enough not to need one.
- [x] I added or updated focused tests for changed non-trivial behavior, or explained why none are needed.
- [x] I updated relevant English and Chinese documentation, or no documentation change is needed. (No user doc describes the agent PATCH body; the OpenAPI operation description now states the semantics.)
- [x] I ran `mise run format && mise run build && mise run test`.
- [x] If this changes agent behavior (tools, prompts, the runner loop): not applicable. The `settings_agent` tool's merge logic is untouched; only the HTTP handler changes.
- [x] If the change touches a surface no eval task exercises: not applicable.
- [x] Any earlier measurement this PR invalidates is marked superseded with its reason, not deleted: not applicable.
