### PR TITLE
🔀 chore(release): sync v0.66.1 metadata back to main

### DIFF
--- a/deploy/helm/stella/Chart.yaml
+++ b/deploy/helm/stella/Chart.yaml
@@ -3,12 +3,12 @@ name: stella
 description: Stella — a single-tenant, multi-user, multi-agent AI assistant platform. Single-replica production chart.
 type: application
 # Chart version — bump on chart changes, independent of the app version.
-version: 0.1.2
+version: 0.1.4
 # appVersion is metadata noting the Stella release this chart was developed
 # against. It is NOT the default image tag: the chart defaults image.tag to
 # "latest" (see stella.image / values.yaml) so a fresh install tracks the newest
 # published release. Pin image.tag or image.digest for reproducible deploys.
-appVersion: "v0.65.0"
+appVersion: "v0.66.1"
 home: https://stella.cherryin.com
 sources:
   - https://github.com/CherryHQ/stella

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.65.0",
+  "version": "0.66.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## What

Sync the v0.66.1 web and Helm release metadata to `main` without merging the stale release branch.

## Why

PR #1216 is conflicting because `release/v0.66` diverged before the package refactor. Merging that branch wholesale would reintroduce obsolete code and discard later `main` work.

## How

- Update the web package version to 0.66.1.
- Update Helm chart version to 0.1.4 and appVersion to v0.66.1.
- Do not replay the release changelog onto `main`: its Unreleased section already contains both release-era and later work; v0.66.2 preparation will establish the correct version boundary from v0.66.1.

## Test

- Verified `web/package.json` is 0.66.1.
- Verified Helm chart version and appVersion.
- Ran `git diff --check`.
- Full build/test skipped: release metadata only; the commit hook ran format and found no web tests affected.

## Refs

No issue: required release metadata sync-back; supersedes #1216.

## Checklist

- [x] No issue linked because this is required release bookkeeping.
- [x] No code behavior changed beyond release metadata.
- [x] English and Chinese changelogs are intentionally deferred to the v0.66.2 preparation PR; replaying the stale release branch would lose later Unreleased content.
- [x] Focused metadata validation and whitespace checks passed; the full suite is not needed for metadata-only changes.
- [x] Agent-behavior eval is not applicable.
- [x] No eval-only surface is changed.
- [x] No earlier measurement is invalidated.
