### PR TITLE
📝 docs(release): make the eval gate risk-based

### DIFF
--- a/web/content/docs/development/rules/release.md
+++ b/web/content/docs/development/rules/release.md
@@ -169,22 +169,26 @@ so failed subprocess journeys remain diagnosable. See `system-test.md`.
 
 ## Agent Performance Gate
 
-Before every release candidate and stable release, run the complete
-Terminal-Bench 2.1 evaluation against the proposed release commit. This is a
-manual release gate because it needs a live model gateway and disposable AWS
-compute; `mise run release:validate` intentionally does not spend that budget.
+Terminal-Bench 2.1 is a manual, risk-based release gate, not a required check
+for every release candidate or stable patch. Run it when the release decision
+needs evidence about agent behavior — in particular after changes to tools,
+prompts, the runner loop, model-facing capabilities, or sandbox behavior — or
+when the release owner explicitly requests it. `mise run release:validate`
+remains the required local pre-cut gate and intentionally does not spend the
+live-model and disposable-AWS budget.
 
 ```bash
 CANDIDATE=$(git rev-parse HEAD)
 mise run eval:tb21:aws -- --commit "$CANDIDATE"
 ```
 
-Do not tag or publish until the run has exactly five selected scoreable trials
-for each of the 89 tasks, its redacted archive and checksums verify, and cloud
-cleanup completes. Archive the result under
+When an evaluation is run, do not tag or publish until it has exactly five
+selected scoreable trials for each of the 89 tasks, its redacted archive and
+checksums verify, and cloud cleanup completes. Archive the result under
 `test/evals/harbor/results/terminal-bench-2.1/` with the evaluated commit in
 its metadata. If agent-affecting code changes after the run, rerun it for the
-new candidate.
+new candidate. The release PR records either the evidence or why evaluation
+was not needed.
 
 Every release record first compares Stella with the prior Stella release to
 show version-to-version movement. A comparison is causal evidence only when

--- a/web/content/docs/development/rules/release.zh.md
+++ b/web/content/docs/development/rules/release.zh.md
@@ -101,19 +101,22 @@ System Test 同时在本地门禁和 tag 触发的 validation job 中运行。�
 
 ## Agent 性能门禁
 
-每个 RC 和 Stable 发布前，都必须针对拟发布 commit 跑完整的
-Terminal-Bench 2.1。它需要在线模型 gateway 和一次性 AWS 计算资源，因此是
-手动发布门禁，`mise run release:validate` 有意不承担这笔成本。
+Terminal-Bench 2.1 是按风险决定的手动发布门禁，不是每个 RC 或 Stable patch
+都必须跑的检查。当发布决策需要 Agent 行为证据时运行它，尤其是改动了工具、prompt、
+runner loop、面向模型的能力或沙箱行为之后，或者 release owner 明确要求时。
+`mise run release:validate` 仍是必须执行的本地 pre-cut gate，并且有意不承担在线
+模型与一次性 AWS 的成本。
 
 ```bash
 CANDIDATE=$(git rev-parse HEAD)
 mise run eval:tb21:aws -- --commit "$CANDIDATE"
 ```
 
-只有 89 道题都选满 5 个 scoreable trial、脱敏 archive 与 checksum 验证通过、
-云资源清理完成，才可以打 tag 或发布。将结果归档到
+一旦决定运行评估，只有 89 道题都选满 5 个 scoreable trial、脱敏 archive 与
+checksum 验证通过、云资源清理完成，才可以打 tag 或发布。将结果归档到
 `test/evals/harbor/results/terminal-bench-2.1/`，metadata 必须记录被测 commit。
-若之后再改动影响 agent 的代码，必须针对新 candidate 重跑。
+若之后再改动影响 agent 的代码，必须针对新 candidate 重跑。release PR 必须记录
+评估证据，或说明为何不需要评估。
 
 每次发布记录首先对照**上一个 Stella release**，用于观察版本间变化。只有 model、
 gateway、dataset、host、timeout、harness 与 capability treatment 一致时，才可作为


### PR DESCRIPTION
## What

Make the Terminal-Bench 2.1 release evaluation a risk-based manual gate in both release-rule languages.

## Why

The prior wording made every RC and stable patch appear blocked on a full AWS evaluation. That is not the release policy: owners request evaluation when the release needs agent-behavior evidence.

## How

- State when evaluation is warranted: agent-facing changes or an explicit release-owner request.
- Keep `mise run release:validate` as the required pre-cut gate.
- Require the release PR to record evaluation evidence or the reason it was not needed.

## Test

- `mise run format` passed.
- `mise run build` passed.
- `git diff --check` passed.
- The commit hook ran format and `mise run test:web`, both passed.
- No AWS evaluation: documentation-only change.

## Refs

No issue: correction to release-process documentation.

## Checklist

- [x] No issue linked because this is a small documentation correction.
- [x] No code behavior changed; focused tests are not applicable.
- [x] English and Chinese documentation are synchronized.
- [x] Formatting, build, whitespace, and web test checks passed.
- [x] Agent-behavior eval is not applicable because this changes documentation only.
- [x] No eval-only surface is changed.
- [x] No earlier measurement is invalidated.
