### PR TITLE
📝 docs(release): define patch-line boundaries

### DIFF
--- a/web/content/docs/development/rules/release.md
+++ b/web/content/docs/development/rules/release.md
@@ -34,6 +34,19 @@ branches named `release/vX.Y`, for example `release/v0.63`:
 - Sync release metadata and any release-only fix back to `main` through a PR.
   Never leave the two lines silently divergent.
 
+A maintained minor branch is a patch line, not a staging branch for the next
+minor release:
+
+- Never merge or rebase all of `main` into an existing `release/vX.Y` branch.
+  A `vX.Y.Z` patch contains only selected fixes for that minor line, normally
+  backported from `main`.
+- If a release must contain the current `main` tree, cut `release/vX.(Y+1)`
+  from `main` and release `vX.(Y+1).0`. Do not express that release by
+  incrementing `Z` on the older line.
+- A sync-back PR flows from `release/vX.Y` to `main` only for release metadata
+  and release-only fixes. It never authorizes a forward merge from `main` into
+  the maintained patch line.
+
 Protect `release/v*` with the same required Format and Test checks as `main`.
 Disallow force-pushes and branch deletion, and require PRs for updates. The tag
 workflow also derives `release/vX.Y` from the version and rejects a tagged

--- a/web/content/docs/development/rules/release.zh.md
+++ b/web/content/docs/development/rules/release.zh.md
@@ -20,6 +20,15 @@ RC 从维护中的 `release/vX.Y` 分支切出，依次发布 `rc.1`、`rc.2`，
 
 `main` 是默认开发分支。每个维护中的小版本使用 `release/vX.Y` 分支：从 `main` 切出后，RC 和 stable 都从该分支发布；实际修复先合并到 `main`，再精确 backport 到 release 分支。
 
+维护中的 minor 分支是 patch 线，不是下一 minor 的暂存分支：
+
+- 绝不将整个 `main` merge 或 rebase 到已有的 `release/vX.Y`。`vX.Y.Z`
+  patch 只能包含该 minor 线选定的修复，通常是从 `main` 精确 backport 的提交。
+- 如果发布必须包含当前完整的 `main` 文件树，应从 `main` 切出
+  `release/vX.(Y+1)` 并发布 `vX.(Y+1).0`，不能在旧线递增 `Z` 来表示它。
+- sync-back PR 只从 `release/vX.Y` 流向 `main`，用于回灌发布元数据与
+  release-only 修复；它绝不授权把 `main` forward-merge 到维护中的 patch 线。
+
 ## 发布流程
 
 1. 选择发布 tag `vX.Y.Z` 或 `vX.Y.Z-rc.N`；Web package 版本为去掉开头 `v` 的相同版本。


### PR DESCRIPTION
## What

Add explicit patch-line boundaries to the bilingual release workflow.

## Why

The previous rule said patches come from a maintained release branch but did not forbid forwarding all of `main` into it. That ambiguity made a next-minor release look like a patch release.

## How

- State that `release/vX.Y` accepts only selected patch fixes.
- Require a new `release/vX.(Y+1)` branch for a release containing current main.
- Limit sync-back to release metadata and release-only fixes.

## Test

- `git diff --check` passed.
- Commit hook ran format and `mise run test:web`, both passed.

## Refs

No issue: small release-process documentation correction.

## Checklist

- [x] No issue linked because this is a small documentation correction.
- [x] No code behavior changed; focused tests are not applicable.
- [x] English and Chinese documentation are synchronized.
- [x] Formatting, whitespace, and web tests passed.
- [x] Agent-behavior eval is not applicable because this changes documentation only.
- [x] No eval-only surface is changed.
- [x] No earlier measurement is invalidated.
