### PR TITLE
🐛 fix(release): prepare cross-platform embedded runtimes

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -7,7 +7,7 @@ before:
     # happened to put on PATH, which is how release binaries ended up embedding
     # an SPA built on a Node version no pull request ever tests. mise.toml pins
     # the toolchain in one place; go through it.
-    - mise run build:embedded
+    - mise run build:embedded:release
 
 builds:
   - id: stellad

--- a/mise.toml
+++ b/mise.toml
@@ -157,6 +157,18 @@ description = "Generate code and build the SPA, i.e. everything the Go binary em
 # together lets mise resolve that dependency once instead of twice.
 depends = ["generate", "build:web"]
 
+[tasks."build:embedded:release"]
+description = "Prepare embedded assets for every GoReleaser platform"
+depends = ["build:embedded"]
+run = """
+# GoReleaser cross-compiles all four supported Unix targets. Exact go:embed
+# names make a missing target asset a compile failure, so fetch every runtime
+# archive before it starts rather than relying on the Linux CI host's cache.
+for target in darwin/amd64 darwin/arm64 linux/amd64 linux/arm64; do
+  TARGET_GOOS=${target%/*} TARGET_GOARCH=${target#*/} go run ./internal/tools/syncembeddedbinaries
+done
+"""
+
 # test depends on generate for the same reason build does: the embedded runtimes
 # must exist for the package to compile, and their absence used to turn the
 # embedded-tool tests into silent skips.


### PR DESCRIPTION
## What

Prepare embedded runtime archives for every GoReleaser target before snapshot and release builds.

## Why

The v0.67.0 release snapshot failed on Linux while cross-compiling darwin/amd64 because the exact go:embed archive had only been generated for the CI host.

## How

- Add `mise run build:embedded:release` to fetch all four Unix target archives.
- Use it from GoReleaser’s pre-build hook.

## Test

- Reproduced the missing darwin/amd64 archive failure from release CI.
- Ran `mise run build:embedded:release && mise run release:snapshot` locally; snapshot crossed the former failing darwin/amd64 build.

## Refs

No issue: release-blocking build correction for v0.67.0.

## Checklist

- [x] No issue linked because this is a release-blocking correction.
- [x] Focused release snapshot validation was run.
- [x] No user documentation change is needed.
- [x] Agent-behavior eval is not applicable.
- [x] No eval-only surface is changed.
- [x] No earlier measurement is invalidated.
