### PR TITLE
🐛 fix: prepare embedded runtimes for Docker releases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,8 @@ RUN --mount=type=secret,id=github_token \
     --mount=type=cache,target=/root/.cache/go-build \
     if [ -f /run/secrets/github_token ]; then export GITHUB_TOKEN="$(cat /run/secrets/github_token)"; fi; \
     env -u GOOS -u GOARCH \
+      TARGET_GOOS=${TARGETOS} TARGET_GOARCH=${TARGETARCH} \
+      mise run build:embedded:runtimes && \
       TARGET_GOOS=${TARGETOS} TARGET_GOARCH=${TARGETARCH} STRIP=1 \
       mise run build
 

--- a/mise.toml
+++ b/mise.toml
@@ -160,10 +160,14 @@ depends = ["generate", "build:web"]
 [tasks."build:embedded:release"]
 description = "Prepare embedded assets for every GoReleaser platform"
 depends = ["build:embedded"]
+run = "mise run build:embedded:runtimes"
+
+[tasks."build:embedded:runtimes"]
+description = "Fetch embedded runtimes for every supported Unix target"
 run = """
 # GoReleaser cross-compiles all four supported Unix targets. Exact go:embed
-# names make a missing target asset a compile failure, so fetch every runtime
-# archive before it starts rather than relying on the Linux CI host's cache.
+# names make a missing target asset a compile failure. Docker builds compile
+# every embed declaration too, so both release paths share this complete set.
 for target in darwin/amd64 darwin/arm64 linux/amd64 linux/arm64; do
   TARGET_GOOS=${target%/*} TARGET_GOARCH=${target#*/} go run ./internal/tools/syncembeddedbinaries
 done


### PR DESCRIPTION
## What

Prepare the complete embedded runtime set before Docker image builds.

## Why

The v0.67.0 Docker linux/arm64 build failed because Go validates every `go:embed` declaration, while the container previously downloaded only the target architecture archive.

## How

- Extract the all-target runtime download into a reusable Mise task.
- Run that task in the Docker builder before the target-specific build.
- Keep GoReleaser on the same task so the two release paths cannot drift.

## Test

- `mise run build:embedded:runtimes`
- `TARGET_GOOS=linux TARGET_GOARCH=arm64 STRIP=1 mise run build`
- `mise run format && mise run build && mise run test`

## Refs

No issue: isolated release-blocking build fix discovered during the v0.67.0 release workflow.

## Checklist

- [x] The PR links a GitHub issue, or states why the fix is small enough not to need one.
- [x] I added or updated focused tests for changed non-trivial behavior, or explained why none are needed: this only changes release build orchestration; the targeted arm64 build reproduces the failed path.
- [x] I updated relevant English and Chinese documentation, or no documentation change is needed: no user-facing behavior or workflow policy changed.
- [x] I ran `mise run format && mise run build && mise run test`.
- [x] If this changes agent behavior (tools, prompts, the runner loop): I included eval evidence with both jobs, commits, tier, k, host, and model, or stated why it is not applicable: not applicable.
- [x] If the change touches a surface no eval task exercises (pixel understanding, document extraction, CRLF fidelity, non-UTF-8, binary handling): I said so, and named the tests that cover it instead: binary embedding is covered by the targeted all-runtime sync and linux/arm64 build.
- [x] Any earlier measurement this PR invalidates is marked superseded with its reason, not deleted: no measurements are affected.
